### PR TITLE
Excel report v2 — cover + 6 sheets, canonical assumptions, incentives, $15k bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ env/
 *.log
 *.sqlite
 *.db
+*.db-shm
+*.db-wal
 
 # Local development settings
 .env.local
@@ -59,5 +61,6 @@ coverage.xml
 data/raw/
 data/processed/
 data/exports/
+data/cache/
 outputs/
 temp/ 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,12 +14,12 @@ Desktop Python/Tkinter app for fleet electrification consulting. Decodes vehicle
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| VIN pipeline (Process tab) | ✓ Working | Core workflow, 226 tests passing |
+| VIN pipeline (Process tab) | ✓ Working | Core workflow, 279 tests passing |
 | Results table | ✓ Working | Right-click menu, ACF override, MPG DB save |
 | Analysis dashboard | ✓ Working | Charts, KPIs, scenario comparison, Gantt |
 | ACF classification | ✓ Working | ZEV/A/B/C/D; HPF/Non-HPF/State Agency support |
 | Electrification timeline | ✓ Working | Phase 28 even-spread w/ GVWR-tiered boost |
-| Excel export (8-tab) | ✓ Working | Override flagging, 4-scenario year columns |
+| Excel export (cover + 6) | ✓ Working | v2 (Phase 29): Cover-linked assumptions, incentives, capital plan, scenarios, action items |
 | PowerPoint export | ⚠️ Known issues | Charts occasionally wrong/incomplete; template quality variable |
 | Timeline tab | ✓ Working (low use) | Inline editing works; rarely needed in practice |
 | Charging tab | 🚧 Stub | UI scaffolding present; no analysis engine yet |
@@ -39,7 +39,7 @@ python3 app.py -b -i in.csv -o out.csv  # Batch mode
 ### Testing
 
 ```bash
-python3 -m pytest tests/ -v           # Run all 226 tests
+python3 -m pytest tests/ -v           # Run all 279 tests
 python3 -m pytest tests/ -v -k acf    # ACF tests only
 python3 -m pytest tests/ -v --tb=short
 ```
@@ -76,7 +76,7 @@ ui/
 analysis/
   calculations.py       → TCO, ROI, emissions, year-by-year cash flow model
   charts.py             → Matplotlib chart generation (22 chart types via ChartFactory)
-  reports.py            → Excel multi-tab report generation (8 worksheets)
+  reports.py            → Excel report generation (v2: cover + 6 worksheets)
   acf_compliance.py     → CARB ACF classification per vehicle (ZEV/A/B/C/D)
   electrification_timeline.py → Score-based even-spread year assignment + GVWR-tiered boost
   ev_database.py        → EV equivalent matching (~25 entries, reliability limited for heavy-duty)
@@ -106,6 +106,7 @@ tests/
   test_match_confidence.py
   test_timeline_override.py
   test_pptx_smoke.py               → 13 headless PPTX assertions (Phase 26)
+  test_excel_report.py             → Excel report v2 structural assertions (Phase 29)
 ```
 
 ---
@@ -216,11 +217,20 @@ Template file: `assets/template_default.pptx`. If building a new/improved templa
 
 `ElectrificationScenario` dataclass has `include_light_duty: bool` field. `compare_scenarios()` returns per-year vehicles/cost/co2/savings. Scope presets run to user-configured horizon year via `dataclasses.replace()`.
 
-### Excel Export
+### Excel Export (v2 — Phase 29: cover + 6 sheets)
 
 - **Results tab "Export"** → single-sheet "Fleet Analysis" (raw vehicle data only)
-- **Analysis tab "Export" or File > Export Report** → 8-tab report: Vehicle Data, Summary, Electrification Analysis, Charging Infrastructure, Emissions Inventory, TCO Model (live Excel formulas), Replacement Schedule, Summary Dashboard
-- **Timelines to Include dialog** (triggered at `.xlsx` export): 4 scenario checkboxes (all checked by default) → additional year columns in Replacement Schedule sheet + amber override flagging
+- **Analysis tab "Export" or File > Export Report** → **cover + 6-sheet** report:
+  0. **Cover & Methodology** — client header (from `PresentationProfile`), **canonical single-source-of-truth assumptions block** (`'Cover & Methodology'!$B$9:$B$18`, keyed by `_ASSUMPTION_ROW` / `cover_aref()`), data-quality KPIs, methodology + data-source note, ACF glossary, disclaimer
+  1. **Vehicle Data** — flat per-VIN table with quality-flag highlighting (MPG estimate amber, low quality/failed red, low match confidence)
+  2. **Fleet Overview** — merged old Summary + Summary Dashboard: KPI band + ACF/fuel/make composition tables with native pie/column charts
+  3. **TCO & Financials** — live cash-flow model (assumption cells B4–B12/B14 mirror the Cover via formula), Funding & Incentives block (`get_all_incentives()`, light/medium_heavy buckets), per-vehicle savings (real `_payback_years`, no $15k hack)
+  4. **Replacement & Capital Plan** — Gantt schedule + per-fiscal-year capital plan (vehicle+infra capex, net-of-incentive, cumulative, over-cap flag) + native spend chart
+  5. **Emissions & Scenarios** — emissions inventory + 4-scenario comparison (`compare_scenarios`) + native CO₂ trajectory chart; projected emissions flagged when `is_synthetic`
+  6. **Infrastructure & Action Items** — charging summary + per-year buildout + Data Gaps punch list
+- `generate()` takes `client_profile` + `state_code` (default `"CA"`); wired from `analysis_panel.export_full_report()` via `sharing_data["presentation_profile"]`.
+- **Timelines to Include dialog** (triggered at `.xlsx` export): 4 scenario checkboxes (all checked by default) → additional year columns in Replacement schedule + amber override flagging
+- Structural tests in `tests/test_excel_report.py`.
 
 ---
 
@@ -266,7 +276,8 @@ Template selection is still secondary in the UI. When a client `.pptx` template 
 |-------|-------------|
 | 26 | PPTX smoke test (13 assertions). Underscore-field CSV guard. HPF/Non-HPF/State Agency fleet type toggle (`ACF_DEADLINE_TABLE_NON_HPF`, `fleet_type` param, 3 radio buttons in Analysis tab). DB CSV bulk import implemented (~115 lines, flexible header aliasing). 220 tests passing. |
 | 27 | ACF display bug fixes (donut, Gantt, Timeline filter all now use `_acf_code` not label). Chart kwargs crash fix. Analysis tab layout reorder (Parameters first). Chart Gallery replaces Chart Browser (main canvas + thumbnail strip, PIL, "Include in PPTX" checkbox). Multi-scenario Gantt view (`_gantt_by_scenario()`). PPTX: `add_co2_trajectory_chart()` + `add_cumulative_investment_chart()`; `scenario_results` wired through `sharing_data`. Present tab: Treeview replaced with 2-column card gallery. Charging tab added (Tab 5, stub). Database shifts to Tab 6. 220 tests passing. |
-| 28 | Cat B even-spread: all Cat B now use score queue with GVWR-tiered boost constants (0.35/0.25/0.15/0.30); CARB deadline stored in `custom_fields["ACF Deadline Year"]` for reference only. New PPTX chart builders: `_add_purchase_schedule_chart()` (4-series A/B/C/D) + `_add_milestone_option_chart()` (Cat B split by GVWR); new optional `timeline_milestone` slide. GHG fix: `_scenario_baseline_co2` now computed via `_calculate_baseline_emissions()` (was always 0.0). `_clear_body_placeholders()` on optional slides. Font patched to Avenir LT Std Book via `scripts/update_template_font.py`. `Fleet.max_vehicles_per_year` + "Max Annual Replacements" spinbox. 226 tests passing (+6). |
+| 28 | Cat B even-spread: all Cat B now use score queue with GVWR-tiered boost constants (0.35/0.25/0.15/0.30); CARB deadline stored in `custom_fields["ACF Deadline Year"]` for reference only. New PPTX chart builders: `_add_purchase_schedule_chart()` (4-series A/B/C/D) + `_add_milestone_option_chart()` (Cat B split by GVWR); new optional `timeline_milestone` slide. GHG fix: `_scenario_baseline_co2` now computed via `_calculate_baseline_emissions()` (was always 0.0). `_clear_body_placeholders()` on optional slides. Font patched to Avenir LT Std Book via `scripts/update_template_font.py`. `Fleet.max_vehicles_per_year` + "Max Annual Replacements" spinbox. 279 tests passing (+6). |
+| 29 | **Excel report v2 rebuild** (`analysis/reports.py`, branch `feature/excel-report-v2`): 8 loosely-coupled sheets → **cover + 6**. New **Cover & Methodology** sheet holds the canonical assumptions block (`cover_aref()` / `_ASSUMPTION_ROW`); TCO cells B4–B12/B14 mirror it by formula (single source of truth). Merged Summary+Dashboard → **Fleet Overview** (native charts); merged Electrification+TCO → **TCO & Financials** (+ Funding & Incentives via `get_all_incentives()`; **fixed the hardcoded $15k EV-premium payback bug** → real `_payback_years`); **Replacement & Capital Plan** (per-year capex, net-of-incentive, over-cap flag); **Emissions & Scenarios** (`compare_scenarios` table + CO₂ trajectory chart, `is_synthetic` flag); **Infrastructure & Action Items** (per-year buildout + data-gap punch list). Vehicle Data gained quality-flag highlighting. `generate()` gained `client_profile` + `state_code`. Removed dead `_create_summary_sheet` / `_create_summary_dashboard_sheet` / `_create_electrification_sheet`. `tests/test_excel_report.py` (+9). 279 tests passing. |
 
 ---
 
@@ -278,6 +289,6 @@ Copy and paste this to start a new development session:
 I'm continuing development of my Fleet Electrification Analyzer app.
 Branch: uiux/v3_0_3 | Version: see settings.py APP_VERSION
 Review CLAUDE.md fully before starting — it is the single source of truth.
-Run: python3 -m pytest tests/ -v (expect 226 passing)
+Run: python3 -m pytest tests/ -v (expect 279 passing)
 Focus this session: [DESCRIBE TASK]
 ```

--- a/analysis/charts.py
+++ b/analysis/charts.py
@@ -738,9 +738,9 @@ class FleetCharts:
 
         ax.set_xlabel("")
         ax.set_ylabel("Count")
-
-        # Rotate x-axis labels for readability
-        plt.xticks(rotation=45, ha='right')
+        ax.tick_params(axis='x', labelrotation=45)
+        for lbl in ax.get_xticklabels():
+            lbl.set_ha('right')
 
         # Insight
         top_make = make_names[0] if make_names else "N/A"
@@ -798,9 +798,9 @@ class FleetCharts:
 
         ax.set_xlabel("")
         ax.set_ylabel("Count")
-
-        # Rotate x-axis labels for readability
-        plt.xticks(rotation=45, ha='right')
+        ax.tick_params(axis='x', labelrotation=45)
+        for lbl in ax.get_xticklabels():
+            lbl.set_ha('right')
 
         top_model = model_names[0] if model_names else "N/A"
         subtitle = f"Top {min(len(model_names), 15)} models — {top_model} is most common ({counts[0]})"
@@ -1420,8 +1420,11 @@ class EmissionsCharts:
             )
             
             # Enhance text readability
-            plt.setp(autotexts, size=8, weight="bold")
-            plt.setp(texts, size=9)
+            for t in autotexts:
+                t.set_size(8)
+                t.set_weight("bold")
+            for t in texts:
+                t.set_size(9)
             
             # Add center text with total
             total_emissions = sum(sizes)

--- a/analysis/reports.py
+++ b/analysis/reports.py
@@ -265,9 +265,9 @@ class ExcelReportGenerator(ReportGenerator):
             if analysis and hasattr(analysis, 'fleet_cash_flows') and analysis.fleet_cash_flows:
                 self._create_tco_model_sheet(workbook, analysis, vehicles, title_format, header_format, cell_format, number_format)
 
-            # Create Charging Infrastructure sheet if available
-            if charging:
-                self._create_charging_sheet(workbook, charging, title_format, header_format, cell_format, number_format)
+            # Infrastructure & Action Items sheet (always — action items need only
+            # vehicles; charging sections are guarded internally).
+            self._create_charging_sheet(workbook, charging, vehicles, title_format, header_format, cell_format, number_format)
 
             # Create Emissions & Scenarios sheet if available
             if emissions:
@@ -882,93 +882,202 @@ class ExcelReportGenerator(ReportGenerator):
             
             row += 1
     
-    def _create_charging_sheet(self, workbook, charging, title_format, header_format, cell_format, number_format):
-        """Create Charging Infrastructure sheet."""
-        # Create worksheet
-        worksheet = workbook.add_worksheet("Charging Infrastructure")
-        
+    def _create_charging_sheet(self, workbook, charging, vehicles, title_format, header_format, cell_format, number_format):
+        """Create Infrastructure & Action Items sheet.
+
+        Top: charging infrastructure summary + recommended layout / phasing, and a
+        per-year buildout phased against the replacement schedule. Bottom: a data
+        gaps / action-items punch list so analysts know what to chase down.
+        """
+        worksheet = workbook.add_worksheet("Infrastructure & Action Items")
+
         # Add title
-        worksheet.merge_range('A1:D1', "Charging Infrastructure Analysis", title_format)
-        
+        worksheet.merge_range('A1:D1', "Infrastructure & Action Items", title_format)
+
         # Set column widths
-        worksheet.set_column('A:A', 25)
-        worksheet.set_column('B:D', 15)
-        
-        # Add parameters section
+        worksheet.set_column('A:A', 28)
+        worksheet.set_column('B:D', 16)
+
         row = 3
-        worksheet.write(row, 0, "Analysis Parameters:", header_format)
-        row += 1
-        
-        worksheet.write(row, 0, "Usage Pattern:")
-        worksheet.write(row, 1, charging.daily_usage_pattern.capitalize())
-        row += 1
-        
-        worksheet.write(row, 0, "Charging Window:")
-        window_text = f"{charging.charging_window[0]}:00 to {charging.charging_window[1]}:00"
-        worksheet.write(row, 1, window_text)
-        row += 1
-        
-        # Add results section
-        row += 2
-        worksheet.write(row, 0, "Infrastructure Requirements:", header_format)
-        row += 1
-        
-        worksheet.write(row, 0, "Level 2 Chargers:")
-        worksheet.write(row, 1, charging.level2_chargers_needed)
-        row += 1
-        
-        worksheet.write(row, 0, "DC Fast Chargers:")
-        worksheet.write(row, 1, charging.dcfc_chargers_needed)
-        row += 1
-        
-        worksheet.write(row, 0, "Maximum Power Required (kW):")
-        worksheet.write(row, 1, charging.max_power_required)
-        row += 1
-        
-        worksheet.write(row, 0, "Estimated Cost ($):")
-        worksheet.write(row, 1, charging.estimated_installation_cost)
-        row += 1
-        
-        # Add recommended layout
-        if charging.recommended_layout and "zones" in charging.recommended_layout:
+        if charging is not None:
+            worksheet.write(row, 0, "Analysis Parameters:", header_format)
+            row += 1
+
+            worksheet.write(row, 0, "Usage Pattern:")
+            worksheet.write(row, 1, charging.daily_usage_pattern.capitalize())
+            row += 1
+
+            worksheet.write(row, 0, "Charging Window:")
+            window_text = f"{charging.charging_window[0]}:00 to {charging.charging_window[1]}:00"
+            worksheet.write(row, 1, window_text)
+            row += 1
+
+            # Add results section
             row += 2
-            worksheet.write(row, 0, "Recommended Layout:", header_format)
+            worksheet.write(row, 0, "Infrastructure Requirements:", header_format)
             row += 1
-            
-            for i, zone in enumerate(charging.recommended_layout["zones"]):
-                worksheet.write(row, 0, f"Zone {i+1}: {zone.get('name', '')}")
+
+            worksheet.write(row, 0, "Level 2 Chargers:")
+            worksheet.write(row, 1, charging.level2_chargers_needed)
+            row += 1
+
+            worksheet.write(row, 0, "DC Fast Chargers:")
+            worksheet.write(row, 1, charging.dcfc_chargers_needed)
+            row += 1
+
+            worksheet.write(row, 0, "Maximum Power Required (kW):")
+            worksheet.write(row, 1, charging.max_power_required)
+            row += 1
+
+            worksheet.write(row, 0, "Estimated Cost ($):")
+            worksheet.write(row, 1, charging.estimated_installation_cost)
+            row += 1
+
+            # Add recommended layout
+            if charging.recommended_layout and "zones" in charging.recommended_layout:
+                row += 2
+                worksheet.write(row, 0, "Recommended Layout:", header_format)
                 row += 1
-                
-                worksheet.write(row, 0, "Level 2 Chargers:")
-                worksheet.write(row, 1, zone.get("level2_chargers", 0))
+
+                for i, zone in enumerate(charging.recommended_layout["zones"]):
+                    worksheet.write(row, 0, f"Zone {i+1}: {zone.get('name', '')}")
+                    row += 1
+
+                    worksheet.write(row, 0, "Level 2 Chargers:")
+                    worksheet.write(row, 1, zone.get("level2_chargers", 0))
+                    row += 1
+
+                    worksheet.write(row, 0, "DC Fast Chargers:")
+                    worksheet.write(row, 1, zone.get("dcfc_chargers", 0))
+                    row += 1
+
+                    worksheet.write(row, 0, "Power Required (kW):")
+                    worksheet.write(row, 1, zone.get("power_required", 0))
+                    row += 1
+
+            # Add phasing plan
+            if charging.recommended_layout and "phasing" in charging.recommended_layout:
+                row += 2
+                worksheet.write(row, 0, "Implementation Phasing:", header_format)
                 row += 1
-                
-                worksheet.write(row, 0, "DC Fast Chargers:")
-                worksheet.write(row, 1, zone.get("dcfc_chargers", 0))
+
+                headers = ["Phase", "Level 2 Chargers", "DC Fast Chargers", "Estimated Cost ($)"]
+                for col, header in enumerate(headers):
+                    worksheet.write(row, col, header, header_format)
                 row += 1
-                
-                worksheet.write(row, 0, "Power Required (kW):")
-                worksheet.write(row, 1, zone.get("power_required", 0))
-                row += 1
-        
-        # Add phasing plan
-        if charging.recommended_layout and "phasing" in charging.recommended_layout:
+
+                for phase in charging.recommended_layout["phasing"]:
+                    worksheet.write(row, 0, f"Phase {phase.get('phase', '')}")
+                    worksheet.write(row, 1, phase.get("level2_chargers", 0))
+                    worksheet.write(row, 2, phase.get("dcfc_chargers", 0))
+                    worksheet.write(row, 3, phase.get("estimated_cost", 0))
+                    row += 1
+
+            # Per-year charger buildout phased against the replacement schedule
+            row = self._write_charging_buildout(
+                worksheet, charging, vehicles, row + 2,
+                header_format, cell_format, number_format)
+        else:
+            worksheet.write(row, 0, "No charging analysis available for this run.", header_format)
             row += 2
-            worksheet.write(row, 0, "Implementation Phasing:", header_format)
+
+        # Data gaps / action items — always shown
+        self._write_action_items(worksheet, workbook, vehicles, row + 2,
+                                 title_format, header_format, cell_format)
+
+    def _write_charging_buildout(self, ws, charging, vehicles, start_row,
+                                 header_format, cell_format, number_format):
+        """Phase charger counts + cost across the years vehicles enter service."""
+        # Vehicles per replacement year
+        counts = {}
+        for v in vehicles:
+            yr = v.custom_fields.get('Proposed EV Year', '')
+            if yr and yr not in ('N/A', 'Exempt', ''):
+                try:
+                    counts[int(yr)] = counts.get(int(yr), 0) + 1
+                except (ValueError, TypeError):
+                    continue
+        years = sorted(counts)
+        total = sum(counts.values()) or 1
+        if not years:
+            return start_row
+
+        l2_total = getattr(charging, 'level2_chargers_needed', 0) or 0
+        dcfc_total = getattr(charging, 'dcfc_chargers_needed', 0) or 0
+        cost_total = float(getattr(charging, 'estimated_installation_cost', 0) or 0)
+
+        import math
+        row = start_row
+        ws.write(row, 0, "Charging Buildout by Year", header_format)
+        row += 1
+        for c, h in enumerate(["Year", "Vehicles", "L2 Chargers", "DC Fast Chargers", "Est. Cost ($)"]):
+            ws.write(row, c, h, header_format)
+        row += 1
+        for yr in years:
+            frac = counts[yr] / total
+            ws.write(row, 0, yr, cell_format)
+            ws.write(row, 1, counts[yr], cell_format)
+            ws.write(row, 2, math.ceil(l2_total * frac), cell_format)
+            ws.write(row, 3, math.ceil(dcfc_total * frac), cell_format)
+            ws.write(row, 4, round(cost_total * frac), number_format)
             row += 1
-            
-            headers = ["Phase", "Level 2 Chargers", "DC Fast Chargers", "Estimated Cost ($)"]
-            for col, header in enumerate(headers):
-                worksheet.write(row, col, header, header_format)
+        return row
+
+    def _write_action_items(self, ws, workbook, vehicles, start_row,
+                            title_format, header_format, cell_format):
+        """Data gaps / action-items punch list for the analyst."""
+        warn_fmt = workbook.add_format({'border': 1, 'bg_color': '#FDE0DC', 'font_color': '#B71C1C'})
+        ok_fmt = workbook.add_format({'border': 1, 'italic': True, 'font_color': '#1E8449'})
+
+        # Per-vehicle issue detection
+        rows = []
+        n_unresolved = n_odo = n_mileage = n_lowconf = n_est = 0
+        for v in vehicles:
+            issues = []
+            if not getattr(v, 'processing_success', True) or not v.vehicle_id.make:
+                issues.append("Unresolved VIN"); n_unresolved += 1
+            if not getattr(v, 'odometer', 0):
+                issues.append("Missing odometer"); n_odo += 1
+            if not getattr(v, 'annual_mileage', 0):
+                issues.append("Missing annual mileage"); n_mileage += 1
+            conf = getattr(v, 'match_confidence', 0) or 0
+            if 0 < conf < 60:
+                issues.append("Low match confidence"); n_lowconf += 1
+            if getattr(v.fuel_economy, 'mpg_is_estimate', False):
+                issues.append("MPG is an estimate"); n_est += 1
+            if issues:
+                rows.append((v.vin or '(no VIN)', "; ".join(issues)))
+
+        row = start_row
+        ws.merge_range(row, 0, row, 3, "Data Gaps & Action Items", title_format)
+        row += 1
+
+        # Summary counts
+        for label, count in [
+            ("Unresolved VINs", n_unresolved),
+            ("Missing odometer", n_odo),
+            ("Missing annual mileage", n_mileage),
+            ("Low match confidence (<60%)", n_lowconf),
+            ("MPG is an estimate", n_est),
+        ]:
+            ws.write(row, 0, label, header_format)
+            ws.write(row, 1, count, warn_fmt if count else cell_format)
             row += 1
-            
-            for phase in charging.recommended_layout["phasing"]:
-                worksheet.write(row, 0, f"Phase {phase.get('phase', '')}")
-                worksheet.write(row, 1, phase.get("level2_chargers", 0))
-                worksheet.write(row, 2, phase.get("dcfc_chargers", 0))
-                worksheet.write(row, 3, phase.get("estimated_cost", 0))
-                row += 1
-    
+        row += 1
+
+        if not rows:
+            ws.write(row, 0, "No data gaps detected — all vehicles fully resolved.", ok_fmt)
+            return
+
+        # Detailed punch list
+        ws.write(row, 0, "VIN", header_format)
+        ws.merge_range(row, 1, row, 3, "Issues to Resolve", header_format)
+        row += 1
+        for vin, issue_text in rows:
+            ws.write(row, 0, vin, cell_format)
+            ws.merge_range(row, 1, row, 3, issue_text, warn_fmt)
+            row += 1
+
     def _create_emissions_sheet(self, workbook, emissions, vehicles, title_format, header_format, cell_format, number_format):
         """Create Emissions & Scenarios sheet.
 

--- a/analysis/reports.py
+++ b/analysis/reports.py
@@ -269,9 +269,9 @@ class ExcelReportGenerator(ReportGenerator):
             if charging:
                 self._create_charging_sheet(workbook, charging, title_format, header_format, cell_format, number_format)
 
-            # Create Emissions Inventory sheet if available
+            # Create Emissions & Scenarios sheet if available
             if emissions:
-                self._create_emissions_sheet(workbook, emissions, title_format, header_format, cell_format, number_format)
+                self._create_emissions_sheet(workbook, emissions, vehicles, title_format, header_format, cell_format, number_format)
 
             max_per_year = getattr(fleet, 'max_vehicles_per_year', 0) if isinstance(fleet, Fleet) else 0
             self._create_replacement_schedule_sheet(
@@ -969,13 +969,19 @@ class ExcelReportGenerator(ReportGenerator):
                 worksheet.write(row, 3, phase.get("estimated_cost", 0))
                 row += 1
     
-    def _create_emissions_sheet(self, workbook, emissions, title_format, header_format, cell_format, number_format):
-        """Create Emissions Inventory sheet."""
+    def _create_emissions_sheet(self, workbook, emissions, vehicles, title_format, header_format, cell_format, number_format):
+        """Create Emissions & Scenarios sheet.
+
+        Top: the emissions inventory (totals + by department / vehicle type / fuel
+        type; canonical home for these breakdowns). Bottom: a side-by-side
+        comparison of the four time-based scenarios plus a native CO₂ trajectory
+        line chart.
+        """
         # Create worksheet
-        worksheet = workbook.add_worksheet("Emissions Inventory")
-        
+        worksheet = workbook.add_worksheet("Emissions & Scenarios")
+
         # Add title
-        worksheet.merge_range('A1:D1', "Fleet Emissions Inventory", title_format)
+        worksheet.merge_range('A1:D1', "Fleet Emissions & Scenario Comparison", title_format)
         
         # Set column widths
         worksheet.set_column('A:A', 25)
@@ -1025,9 +1031,12 @@ class ExcelReportGenerator(ReportGenerator):
         # Add projected data
         if emissions.projected_emissions:
             row += 2
-            worksheet.write(row, 0, "Projected Emissions:", header_format)
+            label = "Projected Emissions:"
+            if getattr(emissions, 'is_synthetic', False):
+                label = "Projected Emissions (illustrative / synthetic):"
+            worksheet.write(row, 0, label, header_format)
             row += 1
-            
+
             headers = ["Year", "Emissions (tons CO2e)"]
             for col, header in enumerate(headers):
                 worksheet.write(row, col, header, header_format)
@@ -1089,12 +1098,100 @@ class ExcelReportGenerator(ReportGenerator):
             
             for ftype, value in sorted(emissions.by_fuel_type.items(), key=lambda x: x[1], reverse=True):
                 percentage = (value / emissions.total_emissions * 100) if emissions.total_emissions > 0 else 0
-                
+
                 worksheet.write(row, 0, ftype)
                 worksheet.write(row, 1, value, number_format)
                 worksheet.write(row, 2, f"{percentage:.1f}%")
                 row += 1
 
+        # ── Scenario comparison + CO₂ trajectory chart ────────────────────────────
+        self._write_scenario_comparison(worksheet, workbook, vehicles, row + 2,
+                                        title_format, header_format, cell_format, number_format)
+
+    def _write_scenario_comparison(self, ws, workbook, vehicles, start_row,
+                                   title_format, header_format, cell_format, number_format):
+        """Side-by-side comparison of the 4 time-based scenarios + CO₂ trajectory chart."""
+        from analysis.scenarios import compare_scenarios
+
+        SHEET = "Emissions & Scenarios"
+        time_based = ["aggressive", "moderate", "conservative", "acf_compliance"]
+        try:
+            comp = compare_scenarios(vehicles, scenario_names=time_based)
+        except Exception as e:  # scenarios are best-effort; never fail the report
+            logger.warning("Scenario comparison skipped: %s", e)
+            return
+
+        table = comp.get("comparison_table", [])
+        scenarios = comp.get("scenarios", [])
+        if not table:
+            return
+
+        money_fmt = workbook.add_format({'border': 1, 'num_format': '$#,##0', 'align': 'right'})
+        num_fmt   = workbook.add_format({'border': 1, 'num_format': '#,##0.0', 'align': 'right'})
+        flag_fmt  = workbook.add_format({'border': 1, 'bold': True, 'bg_color': '#D5F5E3', 'align': 'center'})
+
+        row = start_row
+        ws.merge_range(row, 0, row, 6, "Scenario Comparison (time-based presets)", title_format)
+        row += 1
+        heads = ["Scenario", "Vehicles", "End Year", "Total Investment",
+                 "Annual Savings", "Annual CO₂ Reduction (t)", "Payback (yr)"]
+        for c, h in enumerate(heads):
+            ws.write(row, c, h, header_format)
+        row += 1
+
+        best_roi = comp.get("best_roi", "")
+        lowest_cost = comp.get("lowest_cost", "")
+        fastest = comp.get("fastest", "")
+        for r in table:
+            payback = r.get("payback_years", float('inf'))
+            ws.write(row, 0, r.get("name", ""), cell_format)
+            ws.write(row, 1, r.get("vehicles", 0), cell_format)
+            ws.write(row, 2, r.get("end_year", ""), cell_format)
+            ws.write(row, 3, r.get("total_investment", 0), money_fmt)
+            ws.write(row, 4, r.get("total_annual_savings", 0), money_fmt)
+            ws.write(row, 5, r.get("total_annual_co2_reduction", 0), num_fmt)
+            ws.write(row, 6, "N/A" if payback in (float('inf'), None) else round(payback, 1),
+                     cell_format if payback in (float('inf'), None) else num_fmt)
+            row += 1
+
+        # Best-in-class callouts
+        ws.write(row, 0, "Best ROI:", header_format);       ws.write(row, 1, best_roi, flag_fmt)
+        ws.write(row + 1, 0, "Lowest cost:", header_format); ws.write(row + 1, 1, lowest_cost, flag_fmt)
+        ws.write(row + 2, 0, "Fastest:", header_format);     ws.write(row + 2, 1, fastest, flag_fmt)
+        row += 4
+
+        # ── CO₂ trajectory: cumulative reduction per scenario, per year ───────────
+        all_years = comp.get("all_years", [])
+        if not all_years or not scenarios:
+            return
+        ws.write(row, 0, "Cumulative CO₂ Reduction by Year (metric tons)", header_format)
+        chart_data_header = row + 1
+        # Header row: Year | <scenario names>
+        ws.write(chart_data_header, 0, "Year", header_format)
+        for si, sc in enumerate(scenarios):
+            ws.write(chart_data_header, 1 + si, sc.get("name", f"Scenario {si+1}"), header_format)
+        data_first = chart_data_header + 1
+        for yi, yr in enumerate(all_years):
+            r = data_first + yi
+            ws.write(r, 0, yr, cell_format)
+            for si, sc in enumerate(scenarios):
+                cumul = sc.get("cumulative_co2_reduction", {}) or {}
+                ws.write(r, 1 + si, cumul.get(yr, cumul.get(str(yr), 0)) or 0, num_fmt)
+        data_last = data_first + len(all_years) - 1
+
+        chart = workbook.add_chart({'type': 'line'})
+        for si, sc in enumerate(scenarios):
+            chart.add_series({
+                'name':       [SHEET, chart_data_header, 1 + si],
+                'categories': [SHEET, data_first, 0, data_last, 0],
+                'values':     [SHEET, data_first, 1 + si, data_last, 1 + si],
+                'marker':     {'type': 'circle', 'size': 4},
+            })
+        chart.set_title({'name': 'CO₂ Reduction Trajectory by Scenario'})
+        chart.set_x_axis({'name': 'Year'})
+        chart.set_y_axis({'name': 'Cumulative CO₂ Reduction (t)'})
+        chart.set_size({'width': 640, 'height': 320})
+        ws.insert_chart(chart_data_header, 2 + len(scenarios), chart)
 
     def _create_tco_model_sheet(self, workbook, analysis, vehicles, title_format, header_format, cell_format, number_format):
         """Create TCO Model sheet with a live-formula assumptions block and year-by-year cash flows.

--- a/analysis/reports.py
+++ b/analysis/reports.py
@@ -255,9 +255,10 @@ class ExcelReportGenerator(ReportGenerator):
             # Create Vehicle Data sheet
             self._create_vehicle_data_sheet(workbook, vehicles, fields, title_format, header_format, cell_format, number_format)
             
-            # Create Summary sheet
-            self._create_summary_sheet(workbook, vehicles, title_format, header_format)
-            
+            # Create Fleet Overview sheet (merged Summary + Summary Dashboard)
+            self._create_fleet_overview_sheet(workbook, vehicles, analysis, charging, emissions,
+                                              title_format, header_format, cell_format, number_format)
+
             # Create Electrification Analysis sheet if available
             if analysis:
                 self._create_electrification_sheet(workbook, analysis, title_format, header_format, cell_format, number_format)
@@ -279,8 +280,6 @@ class ExcelReportGenerator(ReportGenerator):
                 title_format, header_format, cell_format, number_format,
                 timeline_options=timeline_options,
             )
-
-            self._create_summary_dashboard_sheet(workbook, vehicles, analysis, charging, emissions, title_format, header_format, cell_format, number_format)
 
             # Close workbook to save changes
             workbook.close()
@@ -451,53 +450,180 @@ class ExcelReportGenerator(ReportGenerator):
                        note_fmt)
 
     def _create_vehicle_data_sheet(self, workbook, vehicles, fields, title_format, header_format, cell_format, number_format):
-        """Create the Vehicle Data sheet with all vehicle information."""
+        """Create the Vehicle Data sheet with all vehicle information.
+
+        Data-quality columns (MPG Source, MPG Estimated, Match Confidence, Data
+        Quality, Processing Status) come straight from to_row_dict(); this method
+        highlights estimated/low-confidence/failed cells so analysts and clients
+        can see at a glance which numbers are soft.
+        """
         # Create worksheet
         worksheet = workbook.add_worksheet("Vehicle Data")
-        
+
+        # Quality-flag formats
+        estimate_fmt = workbook.add_format({'border': 1, 'bg_color': '#FFF3E0'})   # amber — estimate
+        warn_fmt     = workbook.add_format({'border': 1, 'bg_color': '#FDE0DC',
+                                            'font_color': '#B71C1C'})              # red — low quality / failed
+
+        def _pct(value):
+            """Parse '85%' / '85' / 85 -> 85.0; None on failure."""
+            try:
+                return float(str(value).replace('%', '').strip())
+            except (ValueError, TypeError):
+                return None
+
         # Create user-friendly headers
         headers = [COLUMN_NAME_MAP.get(field, field) for field in fields]
-        
+
         # Set column widths
         for i, field in enumerate(fields):
             worksheet.set_column(i, i, 15)  # Default width
-            
+
             # Wider columns for specific fields
             if field in ["VIN", "Make", "Model", "BodyClass"]:
                 worksheet.set_column(i, i, 20)
             elif field in ["Assumed Vehicle (Text)"]:
                 worksheet.set_column(i, i, 30)
-            
+
         # Add title
         worksheet.merge_range('A1:E1', "Fleet Vehicle Data", title_format)
-        
+
         # Add headers
         for col, header in enumerate(headers):
             worksheet.write(2, col, header, header_format)
-        
+
         # Add data
         for row, vehicle in enumerate(vehicles):
             data = vehicle.to_row_dict()
-            
+
             for col, field in enumerate(fields):
                 value = data.get(field, "")
-                
+
+                # Per-cell quality highlighting
+                quality_fmt = None
+                if field == "MPG Estimated" and str(value).strip().lower() == "yes":
+                    quality_fmt = estimate_fmt
+                elif field == "MPG Source" and getattr(vehicle.fuel_economy, "mpg_is_estimate", False):
+                    quality_fmt = estimate_fmt
+                elif field == "Processing Status" and str(value).strip().lower() == "failed":
+                    quality_fmt = warn_fmt
+                elif field == "Data Quality":
+                    p = _pct(value)
+                    if p is not None and p < 60:
+                        quality_fmt = warn_fmt
+                elif field == "Match Confidence":
+                    p = _pct(value)
+                    if p is not None and p < 60:
+                        quality_fmt = estimate_fmt
+
                 # Format numbers appropriately
                 if field in ["MPG City", "MPG Highway", "MPG Combined", "CO2 emissions", "co2A"]:
                     try:
                         value = float(value)
-                        worksheet.write(row + 3, col, value, number_format)
+                        worksheet.write(row + 3, col, value, quality_fmt or number_format)
                     except (ValueError, TypeError):
-                        worksheet.write(row + 3, col, value, cell_format)
+                        worksheet.write(row + 3, col, value, quality_fmt or cell_format)
                 else:
-                    worksheet.write(row + 3, col, value, cell_format)
-        
+                    worksheet.write(row + 3, col, value, quality_fmt or cell_format)
+
         # Freeze header row
         worksheet.freeze_panes(3, 0)
-        
+
         # Auto-filter
         worksheet.autofilter(2, 0, 2 + len(vehicles), len(headers) - 1)
     
+    def _create_fleet_overview_sheet(self, workbook, vehicles, analysis, charging, emissions,
+                                     title_format, header_format, cell_format, number_format):
+        """Fleet Overview — merges the old Summary + Summary Dashboard into one sheet.
+
+        KPI band on top, then composition tables (ACF / fuel / make) each paired
+        with a native Excel chart. Department-emissions and EV-year distributions
+        are intentionally NOT duplicated here — they live on their canonical
+        Emissions & Scenarios and Replacement & Capital Plan sheets.
+        """
+        SHEET = "Fleet Overview"
+        ws = workbook.add_worksheet(SHEET)
+        ws.set_column('A:A', 26)
+        ws.set_column('B:C', 14)
+        ws.hide_gridlines(2)
+
+        kpi_label_fmt = workbook.add_format({
+            'bold': True, 'bg_color': '#EAF2FB', 'border': 1, 'align': 'center', 'font_size': 9})
+        kpi_value_fmt = workbook.add_format({
+            'bold': True, 'font_size': 16, 'align': 'center', 'border': 1})
+        kpi_money_fmt = workbook.add_format({
+            'bold': True, 'font_size': 16, 'align': 'center', 'border': 1, 'num_format': '$#,##0'})
+        count_fmt = workbook.add_format({'border': 1, 'align': 'right'})
+
+        ws.merge_range('A1:H1', "Fleet Electrification — Overview", title_format)
+
+        # ── KPI band ─────────────────────────────────────────────────────────────
+        mpg_vals = [v.fuel_economy.combined_mpg for v in vehicles
+                    if getattr(v.fuel_economy, 'combined_mpg', 0)]
+        avg_mpg = sum(mpg_vals) / len(mpg_vals) if mpg_vals else 0.0
+        coverage = (len(mpg_vals) / len(vehicles) * 100) if vehicles else 0.0
+
+        def _acf(v):
+            return (v.custom_fields.get('_acf_code')
+                    or v.custom_fields.get('ACF Category', '') or '').strip()
+        acf_b = sum(1 for v in vehicles if _acf(v) == 'B')
+
+        kpis = [
+            ("Fleet Size", len(vehicles), kpi_value_fmt),
+            ("Avg MPG", f"{avg_mpg:.1f}", kpi_value_fmt),
+            ("MPG Coverage", f"{coverage:.0f}%", kpi_value_fmt),
+            ("ACF-B Count", acf_b, kpi_value_fmt),
+        ]
+        if analysis is not None:
+            kpis.append(("Total Savings", getattr(analysis, 'total_savings', 0) or 0, kpi_money_fmt))
+            kpis.append(("Payback (yr)", f"{getattr(analysis, 'payback_period', 0) or 0:.1f}", kpi_value_fmt))
+        for col, (label, value, vfmt) in enumerate(kpis):
+            ws.write(2, col, label, kpi_label_fmt)
+            ws.write(3, col, value, vfmt)
+
+        # ── Composition tables + native charts ───────────────────────────────────
+        def _dist(getter):
+            d = {}
+            for v in vehicles:
+                k = getter(v)
+                if k:
+                    d[k] = d.get(k, 0) + 1
+            return sorted(d.items(), key=lambda x: x[1], reverse=True)
+
+        acf_dist  = _dist(_acf)
+        fuel_dist = _dist(lambda v: v.vehicle_id.fuel_type)
+        make_dist = _dist(lambda v: v.vehicle_id.make)[:10]
+
+        def _write_table(start_row, title, rows, chart_type):
+            """Write a 2-col table (category, count) and return chart anchored to the right."""
+            ws.write(start_row, 0, title, header_format)
+            ws.write(start_row, 1, "Count", header_format)
+            r = start_row + 1
+            for name, count in rows:
+                ws.write(r, 0, name, cell_format)
+                ws.write(r, 1, count, count_fmt)
+                r += 1
+            last = r - 1
+            if rows:
+                chart = workbook.add_chart({'type': chart_type})
+                chart.add_series({
+                    'name': title,
+                    'categories': [SHEET, start_row + 1, 0, last, 0],
+                    'values':     [SHEET, start_row + 1, 1, last, 1],
+                    'data_labels': {'value': True} if chart_type == 'pie' else {},
+                })
+                chart.set_title({'name': title})
+                chart.set_size({'width': 360, 'height': 220})
+                if chart_type != 'pie':
+                    chart.set_legend({'none': True})
+                ws.insert_chart(start_row, 3, chart)
+            return r + 1  # next free row (one blank separator)
+
+        row = 6
+        row = _write_table(row, "ACF Classification", acf_dist, 'pie')
+        row = _write_table(row + 11, "Fuel Type", fuel_dist, 'pie')
+        row = _write_table(row + 11, "Top Makes", make_dist, 'column')
+
     def _create_summary_sheet(self, workbook, vehicles, title_format, header_format):
         """Create a summary sheet with fleet statistics and charts."""
         # Create worksheet

--- a/analysis/reports.py
+++ b/analysis/reports.py
@@ -273,10 +273,12 @@ class ExcelReportGenerator(ReportGenerator):
             if emissions:
                 self._create_emissions_sheet(workbook, emissions, title_format, header_format, cell_format, number_format)
 
+            max_per_year = getattr(fleet, 'max_vehicles_per_year', 0) if isinstance(fleet, Fleet) else 0
             self._create_replacement_schedule_sheet(
                 workbook, vehicles,
                 title_format, header_format, cell_format, number_format,
                 timeline_options=timeline_options,
+                charging=charging, max_per_year=max_per_year,
             )
 
             # Close workbook to save changes
@@ -1658,16 +1660,23 @@ class ExcelReportGenerator(ReportGenerator):
 
     def _create_replacement_schedule_sheet(
         self, workbook, vehicles, title_format, header_format, cell_format, number_format,
-        timeline_options: Optional[dict] = None,
+        timeline_options: Optional[dict] = None, charging=None, max_per_year: int = 0,
     ):
-        """Create Replacement Schedule sheet — Gantt-style table.
+        """Create Replacement & Capital Plan sheet.
+
+        Top: the Gantt-style replacement schedule (with scenario year columns and
+        override flagging). Bottom: a per-fiscal-year capital plan (vehicle + infra
+        capex, gross vs net-of-incentive, cumulative, and an over-cap flag) plus a
+        native spend-by-year column chart.
 
         timeline_options: dict of {scenario_key: bool} indicating which scenario
         year columns to append (from the Timelines to Include dialog).
+        charging: optional ChargingAnalysis, used to phase infrastructure capex.
+        max_per_year: Fleet.max_vehicles_per_year budget cap (0 = none) for flagging.
         """
         from analysis.scenarios import get_scenario_year_assignments, PRESET_SCENARIOS
 
-        ws = workbook.add_worksheet("Replacement Schedule")
+        ws = workbook.add_worksheet("Replacement & Capital Plan")
         currency_fmt = workbook.add_format({'border': 1, 'num_format': '$#,##0'})
         year_fmt     = workbook.add_format({'border': 1, 'align': 'center',
                                             'bg_color': '#D6EAF8'})
@@ -1676,7 +1685,7 @@ class ExcelReportGenerator(ReportGenerator):
         yes_fmt      = workbook.add_format({'border': 1, 'align': 'center',
                                             'bg_color': '#FFE0B2', 'bold': True})
 
-        ws.merge_range('A1:F1', "Vehicle Replacement Schedule", title_format)
+        ws.merge_range('A1:F1', "Vehicle Replacement & Capital Plan", title_format)
 
         # Compute scenario year assignments for selected timelines
         active_scenarios: list = []
@@ -1789,6 +1798,110 @@ class ExcelReportGenerator(ReportGenerator):
         total_cost = sum(s['ev_cost'] for s in scheduled)
         ws.write(summary_row + 1, 0, "Total estimated cost:", header_format)
         ws.write(summary_row + 1, 4, total_cost, currency_fmt)
+
+        # ── Capital Plan by Year ──────────────────────────────────────────────────
+        self._write_capital_plan(
+            ws, workbook, scheduled, vehicles, all_years, summary_row + 4,
+            charging, max_per_year,
+            title_format, header_format, cell_format, currency_fmt)
+
+    def _write_capital_plan(self, ws, workbook, scheduled, vehicles, all_years, start_row,
+                            charging, max_per_year,
+                            title_format, header_format, cell_format, currency_fmt):
+        """Per-fiscal-year capital plan appended below the replacement schedule."""
+        from analysis.rate_database import get_all_incentives
+
+        by_vin = {v.vin: v for v in vehicles}
+        inc_cache = dict(getattr(self, '_incentive_per_vehicle', {}) or {})
+
+        def _bucket_incentive(b):
+            if b not in inc_cache:
+                inc_cache[b] = float(get_all_incentives(
+                    getattr(self, '_state_code', 'CA') or 'CA', b).get('max_total', 0) or 0)
+            return inc_cache[b]
+
+        # Per-year aggregates
+        count = {yr: 0 for yr in all_years}
+        gross = {yr: 0.0 for yr in all_years}
+        incentive = {yr: 0.0 for yr in all_years}
+        for s in scheduled:
+            yr = s['ev_year']
+            v = by_vin.get(s['vin_full'])
+            bucket = self._bucket_for_incentive(v) if v is not None else 'medium_heavy'
+            per_veh_inc = min(_bucket_incentive(bucket), s['ev_cost'])
+            count[yr] += 1
+            gross[yr] += s['ev_cost']
+            incentive[yr] += per_veh_inc
+
+        # Infrastructure capex phased proportional to vehicles per year
+        total_infra = float(getattr(charging, 'estimated_installation_cost', 0) or 0) if charging else 0.0
+        n_sched = len(scheduled) or 1
+
+        over_fmt = workbook.add_format({'border': 1, 'align': 'center',
+                                        'bg_color': '#FFCDD2', 'font_color': '#B71C1C', 'bold': True})
+        total_fmt = workbook.add_format({'border': 1, 'bold': True, 'bg_color': '#ECEFF1',
+                                         'num_format': '$#,##0'})
+        total_lbl_fmt = workbook.add_format({'border': 1, 'bold': True, 'bg_color': '#ECEFF1'})
+
+        row = start_row
+        ws.merge_range(row, 0, row, 8, "Capital Plan by Year", title_format)
+        row += 1
+        heads = ["Year", "Vehicles", "Vehicle Capex", "Infra Capex", "Total Capex",
+                 "Est. Incentives", "Net Capex", "Cumulative Net", "Over Cap?"]
+        for c, h in enumerate(heads):
+            ws.write(row, c, h, header_format)
+        header_row = row
+        row += 1
+        data_first = row
+
+        cumulative = 0.0
+        t_count = t_gross = t_infra = t_inc = t_net = 0.0
+        for yr in all_years:
+            infra = total_infra * (count[yr] / n_sched)
+            total_capex = gross[yr] + infra
+            net = max(total_capex - incentive[yr], 0.0)
+            cumulative += net
+            over = (max_per_year and count[yr] > max_per_year)
+            ws.write(row, 0, yr, cell_format)
+            ws.write(row, 1, count[yr], cell_format)
+            ws.write(row, 2, gross[yr], currency_fmt)
+            ws.write(row, 3, infra, currency_fmt)
+            ws.write(row, 4, total_capex, currency_fmt)
+            ws.write(row, 5, incentive[yr], currency_fmt)
+            ws.write(row, 6, net, currency_fmt)
+            ws.write(row, 7, cumulative, currency_fmt)
+            ws.write(row, 8, f"⚠ >{max_per_year}" if over else "", over_fmt if over else cell_format)
+            t_count += count[yr]; t_gross += gross[yr]; t_infra += infra
+            t_inc += incentive[yr]; t_net += net
+            row += 1
+        data_last = row - 1
+
+        # Total row
+        ws.write(row, 0, "TOTAL", total_lbl_fmt)
+        ws.write(row, 1, int(t_count), total_lbl_fmt)
+        ws.write(row, 2, t_gross, total_fmt)
+        ws.write(row, 3, t_infra, total_fmt)
+        ws.write(row, 4, t_gross + t_infra, total_fmt)
+        ws.write(row, 5, t_inc, total_fmt)
+        ws.write(row, 6, t_net, total_fmt)
+        ws.write(row, 7, "", total_lbl_fmt)
+        ws.write(row, 8, "", total_lbl_fmt)
+
+        # Native column chart: Net Capex by year
+        if all_years:
+            SHEET = "Replacement & Capital Plan"
+            chart = workbook.add_chart({'type': 'column'})
+            chart.add_series({
+                'name': 'Net Capex',
+                'categories': [SHEET, data_first, 0, data_last, 0],
+                'values':     [SHEET, data_first, 6, data_last, 6],
+            })
+            chart.set_title({'name': 'Net Capital Outlay by Year'})
+            chart.set_x_axis({'name': 'Year'})
+            chart.set_y_axis({'name': 'Net Capex ($)'})
+            chart.set_legend({'none': True})
+            chart.set_size({'width': 560, 'height': 280})
+            ws.insert_chart(header_row, 10, chart)
 
     def _create_summary_dashboard_sheet(self, workbook, vehicles, analysis, charging, emissions, title_format, header_format, cell_format, number_format):
         """Create Summary Dashboard sheet with KPI reference cells."""

--- a/analysis/reports.py
+++ b/analysis/reports.py
@@ -259,21 +259,19 @@ class ExcelReportGenerator(ReportGenerator):
             self._create_fleet_overview_sheet(workbook, vehicles, analysis, charging, emissions,
                                               title_format, header_format, cell_format, number_format)
 
-            # Create Electrification Analysis sheet if available
-            if analysis:
-                self._create_electrification_sheet(workbook, analysis, title_format, header_format, cell_format, number_format)
-            
+            # TCO & Financials sheet (cash-flow model + incentives + per-vehicle savings).
+            # Per-vehicle savings detail was folded in here from the old standalone
+            # Electrification Analysis sheet.
+            if analysis and hasattr(analysis, 'fleet_cash_flows') and analysis.fleet_cash_flows:
+                self._create_tco_model_sheet(workbook, analysis, vehicles, title_format, header_format, cell_format, number_format)
+
             # Create Charging Infrastructure sheet if available
             if charging:
                 self._create_charging_sheet(workbook, charging, title_format, header_format, cell_format, number_format)
-            
+
             # Create Emissions Inventory sheet if available
             if emissions:
                 self._create_emissions_sheet(workbook, emissions, title_format, header_format, cell_format, number_format)
-
-            # Phase 9I: Analysis-ready sheets
-            if analysis and hasattr(analysis, 'fleet_cash_flows') and analysis.fleet_cash_flows:
-                self._create_tco_model_sheet(workbook, analysis, vehicles, title_format, header_format, cell_format, number_format)
 
             self._create_replacement_schedule_sheet(
                 workbook, vehicles,
@@ -1135,7 +1133,7 @@ class ExcelReportGenerator(ReportGenerator):
             DEFAULT_INFRASTRUCTURE_COST_PER_VEHICLE
         )
 
-        ws = workbook.add_worksheet("TCO Model")
+        ws = workbook.add_worksheet("TCO & Financials")
 
         # ── Formats ─────────────────────────────────────────────────────────────
         currency_fmt = workbook.add_format({'border': 1, 'num_format': '$#,##0', 'align': 'right'})
@@ -1153,6 +1151,14 @@ class ExcelReportGenerator(ReportGenerator):
             'border': 2, 'num_format': '#,##0', 'align': 'right',
             'bg_color': '#EAF2FB'
         })
+        # Mirror formats (grey) — cells linked to the canonical Cover assumptions;
+        # edit on the Cover sheet, not here.
+        mirror_num_fmt = workbook.add_format({
+            'border': 1, 'num_format': '#,##0.00', 'align': 'right', 'bg_color': '#ECEFF1', 'font_color': '#546E7A'})
+        mirror_pct_fmt = workbook.add_format({
+            'border': 1, 'num_format': '0.00', 'align': 'right', 'bg_color': '#ECEFF1', 'font_color': '#546E7A'})
+        mirror_int_fmt = workbook.add_format({
+            'border': 1, 'num_format': '#,##0', 'align': 'right', 'bg_color': '#ECEFF1', 'font_color': '#546E7A'})
         label_fmt    = workbook.add_format({'border': 1, 'bold': False, 'align': 'left'})
         note_fmt     = workbook.add_format({'border': 1, 'italic': True, 'font_color': '#2471A3'})
         payback_fmt  = workbook.add_format({
@@ -1188,9 +1194,9 @@ class ExcelReportGenerator(ReportGenerator):
         ASSUMP_START_ROW  = 3   # 0-idx → Excel row 4  (first input row)
 
         ws.merge_range(ASSUMP_HEADER_ROW, 0, ASSUMP_HEADER_ROW, 9,
-                       "⚙ Assumptions — Edit yellow cells to recalculate the model", header_format)
+                       "⚙ Assumptions — linked to the Cover sheet (edit there to recalculate the model)", header_format)
         ws.write(ASSUMP_HEADER_ROW + 1, 0,
-                 "Changes to yellow cells instantly update all formula cells below.",
+                 "Grey cells mirror the canonical assumptions on the 'Cover & Methodology' sheet.",
                  hint_fmt)
 
         # Derive baseline values from the first vehicle's cash flow data if possible
@@ -1238,12 +1244,31 @@ class ExcelReportGenerator(ReportGenerator):
             ("Avg Annual Mileage (read-only)",  round(avg_mileage, 0),                      input_int_fmt, "B16"),
         ]
 
+        # Cells B4–B12 and B14 mirror the canonical Cover assumptions via formula,
+        # so the entire model is driven from one place. B13 (fleet size) and the
+        # B15/B16 read-only aggregates stay as locally-computed values.
+        MIRROR_TO_COVER = {
+            "B4": "gas_price",        "B5": "electricity_price",   "B6": "ev_efficiency",
+            "B7": "ice_maintenance",  "B8": "ev_maintenance",      "B9": "fuel_escalation",
+            "B10": "discount_rate",   "B11": "battery_degradation", "B12": "infra_cost_per_veh",
+            "B14": "analysis_period",
+        }
+        _mirror_fmt_for = {input_fmt: mirror_num_fmt,
+                           input_pct_fmt: mirror_pct_fmt,
+                           input_int_fmt: mirror_int_fmt}
+
         # Named cells for formula references (0-indexed row, col 1 = column B)
         ASSUMP_ROWS = {}  # key → 0-indexed row number
         for i, (label, value, fmt, cell_hint) in enumerate(assumptions_def):
             r = ASSUMP_START_ROW + i
             ws.write(r, 0, label, label_fmt)
-            ws.write(r, 1, value, fmt)
+            cover_key = MIRROR_TO_COVER.get(cell_hint)
+            if cover_key:
+                # Linked mirror cell — value is the cached fallback until Excel recalcs.
+                ws.write_formula(r, 1, "=" + cover_aref(cover_key),
+                                 _mirror_fmt_for.get(fmt, mirror_num_fmt), value)
+            else:
+                ws.write(r, 1, value, fmt)
             ASSUMP_ROWS[cell_hint] = r  # store for formula building
 
         blank_row = ASSUMP_START_ROW + len(assumptions_def)  # one blank separator row
@@ -1471,6 +1496,165 @@ class ExcelReportGenerator(ReportGenerator):
             r = SUMMARY_START + 1 + j
             ws.write(r, 0, lbl, label_fmt)
             ws.write_formula(r, 1, formula, fmt)
+
+        # ── Funding & Incentives ──────────────────────────────────────────────────
+        next_row = self._write_incentives_block(
+            ws, vehicles, SUMMARY_START + len(kpis) + 3,
+            header_format, label_fmt, currency_fmt, hint_fmt, kpi_title_fmt)
+
+        # ── Per-vehicle savings detail (folded in from the old Electrification sheet) ──
+        if analysis is not None and getattr(analysis, 'vehicle_results', None):
+            self._write_per_vehicle_savings(
+                ws, vehicles, analysis, next_row + 2,
+                header_format, label_fmt, currency_fmt, number_format, cell_format, hint_fmt)
+
+    def _bucket_for_incentive(self, vehicle) -> str:
+        """Map a vehicle to an incentive vehicle_class bucket: 'light' or 'medium_heavy'.
+
+        ACF-A is light-duty (GVWR ≤ 8,500 lbs); everything else mandate-relevant is
+        treated as medium/heavy for incentive purposes.
+        """
+        code = (vehicle.custom_fields.get('_acf_code')
+                or vehicle.custom_fields.get('ACF Category', '') or '').strip().upper()
+        if code == 'A':
+            return 'light'
+        return 'medium_heavy'
+
+    def _write_incentives_block(self, ws, vehicles, start_row,
+                                header_format, label_fmt, currency_fmt, hint_fmt, kpi_title_fmt):
+        """Append a Funding & Incentives table to the TCO & Financials sheet.
+
+        Groups replaceable vehicles into incentive buckets, looks up the max
+        stackable federal+state incentive per bucket for the report's region, and
+        shows gross EV cost, max incentive, and net cost after incentives. Also
+        caches per-bucket per-vehicle incentive on self for the Capital Plan sheet.
+        """
+        from analysis.rate_database import get_all_incentives
+
+        state = getattr(self, '_state_code', 'CA') or 'CA'
+
+        # Aggregate by bucket — only vehicles with a real EV purchase price.
+        buckets = {}  # bucket -> {count, gross}
+        for v in vehicles:
+            price = float(v.custom_fields.get('_ev_purchase_price', 0) or 0)
+            code = (v.custom_fields.get('_acf_code')
+                    or v.custom_fields.get('ACF Category', '') or '').strip().upper()
+            if price <= 0 or code == 'ZEV':
+                continue
+            b = self._bucket_for_incentive(v)
+            entry = buckets.setdefault(b, {'count': 0, 'gross': 0.0})
+            entry['count'] += 1
+            entry['gross'] += price
+
+        # Per-vehicle max incentive per bucket (cached for the Capital Plan sheet).
+        self._incentive_per_vehicle = {}
+
+        row = start_row
+        ws.merge_range(row, 0, row, 5,
+                       f"Funding & Incentives  (region: {state} — max stackable, planning upper bound)",
+                       header_format)
+        row += 1
+        col_heads = ["Vehicle Group", "Vehicles", "Gross EV Cost",
+                     "Max Incentive / Veh", "Est. Max Fleet Incentive", "Net Cost After Incentives"]
+        for c, h in enumerate(col_heads):
+            ws.write(row, c, h, header_format)
+        row += 1
+
+        bucket_labels = {'light': 'Light-Duty (ACF-A)', 'medium_heavy': 'Medium/Heavy (ACF-B/C/D)'}
+        tot_count = tot_gross = tot_incentive = 0.0
+        for b in ('light', 'medium_heavy'):
+            if b not in buckets:
+                continue
+            data = buckets[b]
+            inc = get_all_incentives(state, b)
+            per_veh = float(inc.get('max_total', 0) or 0)
+            self._incentive_per_vehicle[b] = per_veh
+            fleet_inc = min(per_veh * data['count'], data['gross'])  # never exceed gross
+            net = max(data['gross'] - fleet_inc, 0.0)
+            ws.write(row, 0, bucket_labels[b], label_fmt)
+            ws.write(row, 1, data['count'], label_fmt)
+            ws.write(row, 2, data['gross'], currency_fmt)
+            ws.write(row, 3, per_veh, currency_fmt)
+            ws.write(row, 4, fleet_inc, currency_fmt)
+            ws.write(row, 5, net, currency_fmt)
+            tot_count += data['count']; tot_gross += data['gross']; tot_incentive += fleet_inc
+            row += 1
+
+        if not buckets:
+            ws.write(row, 0, "No vehicles with EV pricing available for incentive analysis.", hint_fmt)
+            row += 1
+        else:
+            ws.write(row, 0, "TOTAL", kpi_title_fmt)
+            ws.write(row, 1, int(tot_count), kpi_title_fmt)
+            ws.write(row, 2, tot_gross, currency_fmt)
+            ws.write(row, 3, "", kpi_title_fmt)
+            ws.write(row, 4, tot_incentive, currency_fmt)
+            ws.write(row, 5, max(tot_gross - tot_incentive, 0.0), currency_fmt)
+            row += 1
+        ws.write(row, 0,
+                 "Federal: IRA 45W (commercial) + 30D (light). State programs vary by region. "
+                 "Amounts are program maxima and may not all stack in practice — validate before procurement.",
+                 hint_fmt)
+        return row + 1
+
+    def _write_per_vehicle_savings(self, ws, vehicles, analysis, start_row,
+                                   header_format, label_fmt, currency_fmt,
+                                   number_format, cell_format, hint_fmt):
+        """Per-vehicle savings table (folded in from the old Electrification sheet).
+
+        Payback uses each vehicle's real EV purchase price and pre-computed
+        _payback_years rather than the former hardcoded $15,000 premium.
+        """
+        by_vin = {v.vin: v for v in vehicles}
+        results = analysis.vehicle_results or {}
+        order = [vin for vin in (getattr(analysis, 'prioritized_vehicles', None) or []) if vin in results]
+        if not order:
+            order = [vin for vin, _ in sorted(
+                results.items(), key=lambda x: x[1].get("total_npv_savings", 0), reverse=True)]
+
+        row = start_row
+        ws.merge_range(row, 0, row, 6, "Per-Vehicle Savings Detail", header_format)
+        row += 1
+        heads = ["Vehicle", "Annual Mileage", "MPG", "Annual Fuel Savings",
+                 "Lifetime Fuel Savings", "CO₂ Reduction (t)", "Payback (yr)"]
+        for c, h in enumerate(heads):
+            ws.write(row, c, h, header_format)
+        row += 1
+
+        for vin in order:
+            data = results[vin]
+            v = by_vin.get(vin)
+            display = data.get("display_name", vin)
+            annual_mileage = data.get("annual_mileage", 0)
+            mpg = data.get("mpg", 0)
+            annual_fuel = data.get("annual_fuel_savings", 0)
+            lifetime_fuel = data.get("total_fuel_savings", 0)
+            co2 = data.get("total_co2_reduction", 0)
+
+            # Real per-vehicle payback — prefer the pre-computed value, else derive
+            # from the actual EV purchase premium (NOT a flat $15k).
+            payback = None
+            if v is not None:
+                pb = v.custom_fields.get('_payback_years')
+                try:
+                    payback = float(pb) if pb not in (None, '', 'N/A') else None
+                except (ValueError, TypeError):
+                    payback = None
+                if payback is None:
+                    premium = float(v.custom_fields.get('_ev_purchase_price', 0) or 0)
+                    annual_total = annual_fuel + data.get("annual_maintenance_savings", 0)
+                    payback = premium / annual_total if (premium > 0 and annual_total > 0) else None
+
+            ws.write(row, 0, display, cell_format)
+            ws.write(row, 1, annual_mileage, number_format)
+            ws.write(row, 2, mpg, number_format)
+            ws.write(row, 3, annual_fuel, currency_fmt)
+            ws.write(row, 4, lifetime_fuel, currency_fmt)
+            ws.write(row, 5, co2, number_format)
+            ws.write(row, 6, "N/A" if payback is None else round(payback, 1),
+                     cell_format if payback is None else number_format)
+            row += 1
+        return row
 
     def _create_replacement_schedule_sheet(
         self, workbook, vehicles, title_format, header_format, cell_format, number_format,

--- a/analysis/reports.py
+++ b/analysis/reports.py
@@ -40,6 +40,47 @@ except ImportError:
 
 
 ###############################################################################
+# Canonical assumptions — single source of truth on the Cover sheet
+###############################################################################
+# Every financial sheet references these cells via cover_aref(); the Cover sheet
+# is the only place a user edits them. Percentages are stored as whole numbers
+# (e.g. 3.0 = 3%/yr) to match the TCO model's existing formula convention.
+
+COVER_SHEET_NAME = "Cover & Methodology"
+
+# First assumption value lives in column B of this 1-indexed Excel row.
+_ASSUMPTION_FIRST_ROW = 9
+
+# Ordered list of (key, label, kind). kind ∈ {money2, money0, num2, pct, int}.
+_ASSUMPTION_DEFS = [
+    ("gas_price",           "Gas price ($/gal)",                  "money2"),
+    ("electricity_price",   "Electricity price ($/kWh)",          "money2"),
+    ("ev_efficiency",       "EV efficiency (kWh/mile)",           "num2"),
+    ("ice_maintenance",     "ICE maintenance ($/mile)",           "money2"),
+    ("ev_maintenance",      "EV maintenance ($/mile)",            "money2"),
+    ("fuel_escalation",     "Fuel escalation (%/yr)",             "pct"),
+    ("discount_rate",       "Discount rate (%/yr)",               "pct"),
+    ("battery_degradation", "Battery degradation (%/yr)",         "pct"),
+    ("infra_cost_per_veh",  "Infrastructure cost / vehicle ($)",  "money0"),
+    ("analysis_period",     "Analysis period (years)",            "int"),
+]
+
+# key -> 1-indexed Excel row of its value cell in column B of the Cover sheet.
+_ASSUMPTION_ROW = {
+    key: _ASSUMPTION_FIRST_ROW + i for i, (key, _label, _kind) in enumerate(_ASSUMPTION_DEFS)
+}
+
+
+def cover_aref(key: str) -> str:
+    """Absolute cross-sheet reference to a canonical assumption cell (no leading '=').
+
+    e.g. cover_aref("gas_price") -> "'Cover & Methodology'!$B$9"
+    Wrap in "=" + cover_aref(...) to write a mirror formula, or embed in a larger one.
+    """
+    return f"'{COVER_SHEET_NAME}'!$B${_ASSUMPTION_ROW[key]}"
+
+
+###############################################################################
 # Report Generator Base Class
 ###############################################################################
 
@@ -137,17 +178,22 @@ class ExcelReportGenerator(ReportGenerator):
                charging: Optional[ChargingAnalysis] = None,
                emissions: Optional[EmissionsInventory] = None,
                fields: Optional[List[str]] = None,
-               timeline_options: Optional[dict] = None) -> bool:
+               timeline_options: Optional[dict] = None,
+               client_profile: Optional[Any] = None,
+               state_code: str = "CA") -> bool:
         """
         Generate an Excel report with data, charts, and analysis.
-        
+
         Args:
             fleet: Fleet object or list of vehicles
             analysis: Optional electrification analysis
             charging: Optional charging analysis
             emissions: Optional emissions inventory
             fields: List of fields to include (None for default fields)
-            
+            timeline_options: scenario year columns to append to Replacement sheet
+            client_profile: Optional PresentationProfile for cover-page client/date/presenter
+            state_code: Two-letter state code for incentive lookups (default "CA")
+
         Returns:
             True if successful, False otherwise
         """
@@ -195,7 +241,17 @@ class ExcelReportGenerator(ReportGenerator):
                 'border': 1,
                 'num_format': '#,##0.0'
             })
-            
+
+            # Stash report-wide context for sheet builders
+            self._client_profile = client_profile
+            self._state_code = state_code or "CA"
+
+            # Create Cover & Methodology sheet FIRST so cross-sheet assumption
+            # references ('Cover & Methodology'!$B$N) resolve for later sheets.
+            self._create_cover_sheet(workbook, vehicles, analysis, charging, emissions,
+                                     client_profile, title_format, header_format,
+                                     cell_format, number_format)
+
             # Create Vehicle Data sheet
             self._create_vehicle_data_sheet(workbook, vehicles, fields, title_format, header_format, cell_format, number_format)
             
@@ -236,6 +292,164 @@ class ExcelReportGenerator(ReportGenerator):
             logger.error(f"Error generating Excel report: {e}")
             return False
     
+    def _create_cover_sheet(self, workbook, vehicles, analysis, charging, emissions,
+                            client_profile, title_format, header_format,
+                            cell_format, number_format):
+        """Create the Cover & Methodology sheet.
+
+        Holds the canonical (single-source-of-truth) assumptions block that every
+        financial sheet references, plus client header, data-quality KPIs, a
+        methodology / data-source note, and the ACF glossary.
+        """
+        from settings import (
+            DEFAULT_GAS_PRICE, DEFAULT_ELECTRICITY_PRICE, DEFAULT_EV_EFFICIENCY,
+            DEFAULT_ICE_MAINTENANCE, DEFAULT_EV_MAINTENANCE,
+            DEFAULT_FUEL_ESCALATION_RATE, DEFAULT_BATTERY_DEGRADATION,
+            DEFAULT_INFRASTRUCTURE_COST_PER_VEHICLE,
+        )
+
+        ws = workbook.add_worksheet(COVER_SHEET_NAME)
+        ws.set_column('A:A', 34)
+        ws.set_column('B:B', 20)
+        ws.set_column('C:F', 16)
+        ws.hide_gridlines(2)
+
+        # ── Formats ──────────────────────────────────────────────────────────────
+        big_title_fmt = workbook.add_format({
+            'bold': True, 'font_size': 22, 'font_color': '#3C465A', 'valign': 'vcenter'})
+        client_fmt = workbook.add_format({
+            'bold': True, 'font_size': 16, 'font_color': '#C45911', 'valign': 'vcenter'})
+        meta_fmt = workbook.add_format({'font_size': 11, 'font_color': '#444444'})
+        section_fmt = workbook.add_format({
+            'bold': True, 'font_size': 12, 'bg_color': '#3C465A', 'font_color': 'white',
+            'border': 1, 'align': 'left', 'valign': 'vcenter'})
+        label_fmt = workbook.add_format({'border': 1, 'align': 'left'})
+        note_fmt = workbook.add_format({'italic': True, 'font_size': 9, 'font_color': '#7F8C8D'})
+        body_fmt = workbook.add_format({'text_wrap': True, 'valign': 'top', 'font_size': 10})
+        kpi_label_fmt = workbook.add_format({
+            'bold': True, 'bg_color': '#EAF2FB', 'border': 1, 'align': 'center', 'font_size': 9})
+        kpi_value_fmt = workbook.add_format({
+            'bold': True, 'font_size': 16, 'align': 'center', 'border': 1})
+        # Editable canonical assumption cells (yellow) — the only place users edit.
+        money2_in = workbook.add_format({'border': 2, 'bg_color': '#FFF9C4', 'num_format': '$#,##0.00', 'align': 'right'})
+        money0_in = workbook.add_format({'border': 2, 'bg_color': '#FFF9C4', 'num_format': '$#,##0', 'align': 'right'})
+        num2_in   = workbook.add_format({'border': 2, 'bg_color': '#FFF9C4', 'num_format': '#,##0.00', 'align': 'right'})
+        pct_in    = workbook.add_format({'border': 2, 'bg_color': '#FFF9C4', 'num_format': '0.00"%"', 'align': 'right'})
+        int_in    = workbook.add_format({'border': 2, 'bg_color': '#FFF9C4', 'num_format': '#,##0', 'align': 'right'})
+        _in_fmt = {'money2': money2_in, 'money0': money0_in, 'num2': num2_in, 'pct': pct_in, 'int': int_in}
+
+        # ── Header block (rows 1–6, 1-indexed) ───────────────────────────────────
+        prof = client_profile
+        client_name = (getattr(prof, 'client_name', '') or '').strip() or "Fleet Electrification Analysis"
+        meeting_date = (getattr(prof, 'meeting_date', '') or '').strip()
+        presenter = (getattr(prof, 'presenter_name', '') or '').strip()
+        presenter_co = (getattr(prof, 'presenter_company', '') or '').strip()
+        report_date = datetime.datetime.now().strftime("%B %d, %Y")
+
+        ws.set_row(0, 30)
+        ws.merge_range('A1:F1', "Fleet Electrification Analysis", big_title_fmt)
+        ws.set_row(1, 24)
+        ws.merge_range('A2:F2', client_name, client_fmt)
+        ws.write(2, 0, f"Report generated: {report_date}", meta_fmt)
+        prepared = "Prepared by: " + (f"{presenter}" + (f", {presenter_co}" if presenter_co else "") if presenter else (presenter_co or "—"))
+        ws.write(3, 0, prepared, meta_fmt)
+        if meeting_date:
+            ws.write(4, 0, f"Meeting date: {meeting_date}", meta_fmt)
+        ws.write(5, 0, f"Fleet size: {len(vehicles)} vehicles   |   Incentive region: {self._state_code}", meta_fmt)
+
+        # ── Global assumptions (header row 8; values rows 9..) ────────────────────
+        ws.merge_range('A8:C8', "Global Assumptions  (edit yellow cells — drives the TCO & Financials model)", section_fmt)
+
+        # Seed values: prefer the analysis object, else settings defaults.
+        def _a(attr, default):
+            return getattr(analysis, attr, default) if analysis is not None else default
+        seeds = {
+            "gas_price":           _a('gas_price', DEFAULT_GAS_PRICE),
+            "electricity_price":   _a('electricity_price', DEFAULT_ELECTRICITY_PRICE),
+            "ev_efficiency":       _a('ev_efficiency', DEFAULT_EV_EFFICIENCY),
+            "ice_maintenance":     DEFAULT_ICE_MAINTENANCE,
+            "ev_maintenance":      DEFAULT_EV_MAINTENANCE,
+            "fuel_escalation":     DEFAULT_FUEL_ESCALATION_RATE,
+            "discount_rate":       _a('discount_rate', 5.0),
+            "battery_degradation": DEFAULT_BATTERY_DEGRADATION,
+            "infra_cost_per_veh":  DEFAULT_INFRASTRUCTURE_COST_PER_VEHICLE,
+            "analysis_period":     int(_a('analysis_period', 12) or 12),
+        }
+        for key, label, kind in _ASSUMPTION_DEFS:
+            r0 = _ASSUMPTION_ROW[key] - 1  # 0-indexed
+            ws.write(r0, 0, label, label_fmt)
+            ws.write_number(r0, 1, float(seeds[key]), _in_fmt[kind])
+        note_row = _ASSUMPTION_FIRST_ROW + len(_ASSUMPTION_DEFS)  # 1-indexed row after block
+        ws.write(note_row, 0,
+                 "Yellow cells are the single source of truth; the TCO & Financials sheet mirrors them.",
+                 note_fmt)
+
+        # ── Data quality summary KPIs ────────────────────────────────────────────
+        row = note_row + 2  # 0-indexed cursor (note_row is 1-indexed → already one below)
+        ws.merge_range(row, 0, row, 5, "Data Quality Summary", section_fmt)
+        row += 1
+
+        q_scores = [getattr(v, 'data_quality_score', 0.0) for v in vehicles]
+        avg_quality = sum(q_scores) / len(q_scores) if q_scores else 0.0
+        with_mpg = [v for v in vehicles if getattr(v.fuel_economy, 'combined_mpg', 0)]
+        est_count = sum(1 for v in with_mpg if getattr(v.fuel_economy, 'mpg_is_estimate', False))
+        pct_est = (est_count / len(with_mpg) * 100) if with_mpg else 0.0
+        unresolved = sum(1 for v in vehicles
+                         if not getattr(v, 'processing_success', True) or not v.vehicle_id.make)
+        conf_vals = [getattr(v, 'match_confidence', 0.0) for v in vehicles
+                     if getattr(v, 'match_confidence', 0.0) > 0]
+        avg_conf = sum(conf_vals) / len(conf_vals) if conf_vals else 0.0
+
+        kpis = [
+            ("Avg Data Quality", f"{avg_quality:.0f}%"),
+            ("MPG Estimated", f"{pct_est:.0f}%"),
+            ("Unresolved VINs", f"{unresolved}"),
+            ("Avg Match Conf.", f"{avg_conf:.0f}%"),
+        ]
+        for col, (label, value) in enumerate(kpis):
+            ws.write(row, col, label, kpi_label_fmt)
+            ws.write(row + 1, col, value, kpi_value_fmt)
+        ws.write(row + 2, 0, "See the 'Infrastructure & Action Items' sheet for the vehicle-level data-gap punch list.", note_fmt)
+        row += 4
+
+        # ── Methodology & data sources ───────────────────────────────────────────
+        ws.merge_range(row, 0, row, 5, "Methodology & Data Sources", section_fmt)
+        row += 1
+        methodology = (
+            "VINs are decoded via the NHTSA vPIC API (make, model, year, GVWR, body class, fuel type). "
+            "MPG is resolved through a tiered cascade: FuelEconomy.gov (light-duty) → commercial sources "
+            "(Fuelly / EPA SmartWay / OEM) → an analyst-maintained SQLite reference DB → an EPA class-average "
+            "estimate by GVWR bucket (flagged as an estimate). Each vehicle is classified for CARB Advanced "
+            "Clean Fleets (ACF) and assigned a proposed electrification year via a score-based even-spread "
+            "model. Financials (TCO, savings, payback) come from a year-by-year cash-flow model driven by the "
+            "assumptions above. Incentives reflect the selected region and are applied to net cost."
+        )
+        ws.merge_range(row, 0, row + 4, 5, methodology, body_fmt)
+        row += 6
+
+        # ── ACF glossary ─────────────────────────────────────────────────────────
+        ws.merge_range(row, 0, row, 5, "ACF Classification Glossary", section_fmt)
+        row += 1
+        glossary = [
+            ("ZEV", "Already zero-emission — no replacement required."),
+            ("A",   "Exempt, light-duty (GVWR ≤ 8,500 lbs)."),
+            ("B",   "Mandate-subject, medium/heavy-duty — drives the compliance timeline."),
+            ("C",   "Exempt by body type (dump truck, crane, concrete mixer, etc.)."),
+            ("D",   "Emergency vehicle (PPV/SSV, ambulance, fire apparatus)."),
+        ]
+        for code, desc in glossary:
+            ws.write(row, 0, code, workbook.add_format({'border': 1, 'bold': True, 'align': 'center'}))
+            ws.merge_range(row, 1, row, 5, desc, label_fmt)
+            row += 1
+        row += 1
+
+        # ── Disclaimer ───────────────────────────────────────────────────────────
+        ws.merge_range(row, 0, row + 1, 5,
+                       "Estimates are for planning purposes only and depend on input data quality and "
+                       "assumptions. Figures flagged as estimates (e.g. EPA class-average MPG, synthetic "
+                       "emissions projections) should be validated before procurement decisions.",
+                       note_fmt)
+
     def _create_vehicle_data_sheet(self, workbook, vehicles, fields, title_format, header_format, cell_format, number_format):
         """Create the Vehicle Data sheet with all vehicle information."""
         # Create worksheet

--- a/analysis/reports.py
+++ b/analysis/reports.py
@@ -259,20 +259,16 @@ class ExcelReportGenerator(ReportGenerator):
             self._create_fleet_overview_sheet(workbook, vehicles, analysis, charging, emissions,
                                               title_format, header_format, cell_format, number_format)
 
-            # TCO & Financials sheet (cash-flow model + incentives + per-vehicle savings).
-            # Per-vehicle savings detail was folded in here from the old standalone
-            # Electrification Analysis sheet.
+            # Sheet order (cover + 6): Cover → Vehicle Data → Fleet Overview →
+            # TCO & Financials → Replacement & Capital Plan → Emissions & Scenarios
+            # → Infrastructure & Action Items.
+
+            # TCO & Financials sheet (cash-flow model + incentives + per-vehicle
+            # savings; per-vehicle detail folded in from the old Electrification sheet).
             if analysis and hasattr(analysis, 'fleet_cash_flows') and analysis.fleet_cash_flows:
                 self._create_tco_model_sheet(workbook, analysis, vehicles, title_format, header_format, cell_format, number_format)
 
-            # Infrastructure & Action Items sheet (always — action items need only
-            # vehicles; charging sections are guarded internally).
-            self._create_charging_sheet(workbook, charging, vehicles, title_format, header_format, cell_format, number_format)
-
-            # Create Emissions & Scenarios sheet if available
-            if emissions:
-                self._create_emissions_sheet(workbook, emissions, vehicles, title_format, header_format, cell_format, number_format)
-
+            # Replacement & Capital Plan
             max_per_year = getattr(fleet, 'max_vehicles_per_year', 0) if isinstance(fleet, Fleet) else 0
             self._create_replacement_schedule_sheet(
                 workbook, vehicles,
@@ -280,6 +276,14 @@ class ExcelReportGenerator(ReportGenerator):
                 timeline_options=timeline_options,
                 charging=charging, max_per_year=max_per_year,
             )
+
+            # Emissions & Scenarios (if emissions available)
+            if emissions:
+                self._create_emissions_sheet(workbook, emissions, vehicles, title_format, header_format, cell_format, number_format)
+
+            # Infrastructure & Action Items sheet (always — action items need only
+            # vehicles; charging sections are guarded internally).
+            self._create_charging_sheet(workbook, charging, vehicles, title_format, header_format, cell_format, number_format)
 
             # Close workbook to save changes
             workbook.close()
@@ -624,264 +628,6 @@ class ExcelReportGenerator(ReportGenerator):
         row = _write_table(row + 11, "Fuel Type", fuel_dist, 'pie')
         row = _write_table(row + 11, "Top Makes", make_dist, 'column')
 
-    def _create_summary_sheet(self, workbook, vehicles, title_format, header_format):
-        """Create a summary sheet with fleet statistics and charts."""
-        # Create worksheet
-        worksheet = workbook.add_worksheet("Summary")
-        
-        # Add title
-        worksheet.merge_range('A1:D1', "Fleet Summary", title_format)
-        
-        # Set column widths
-        worksheet.set_column('A:A', 20)
-        worksheet.set_column('B:B', 15)
-        worksheet.set_column('C:D', 10)
-        
-        # Basic statistics
-        row = 3
-        worksheet.write(row, 0, "Total Vehicles:", header_format)
-        worksheet.write(row, 1, len(vehicles))
-        
-        # Count makes and models
-        makes = {}
-        models = {}
-        fuel_types = {}
-        body_classes = {}
-        
-        # Calculate stats
-        mpg_values = []
-        co2_values = []
-        
-        for vehicle in vehicles:
-            # Count makes
-            make = vehicle.vehicle_id.make
-            if make:
-                makes[make] = makes.get(make, 0) + 1
-            
-            # Count models
-            model = vehicle.vehicle_id.model
-            if model:
-                models[model] = models.get(model, 0) + 1
-            
-            # Count fuel types
-            fuel_type = vehicle.vehicle_id.fuel_type
-            if fuel_type:
-                fuel_types[fuel_type] = fuel_types.get(fuel_type, 0) + 1
-            
-            # Count body classes
-            body_class = vehicle.vehicle_id.body_class
-            if body_class:
-                body_classes[body_class] = body_classes.get(body_class, 0) + 1
-            
-            # MPG stats
-            mpg = vehicle.fuel_economy.combined_mpg
-            if mpg and mpg > 0:
-                mpg_values.append(mpg)
-            
-            # CO2 stats
-            co2 = vehicle.fuel_economy.co2_primary
-            if co2 and co2 > 0:
-                co2_values.append(co2)
-        
-        # Add make distribution
-        row += 2
-        worksheet.write(row, 0, "Make Distribution:", header_format)
-        row += 1
-        
-        # Sort makes by count
-        sorted_makes = sorted(makes.items(), key=lambda x: x[1], reverse=True)
-        for make, count in sorted_makes[:10]:  # Top 10
-            worksheet.write(row, 0, make)
-            worksheet.write(row, 1, count)
-            # Add simple bar using cell background
-            for i in range(min(count, 10)):
-                worksheet.write(row, 2 + i, "", workbook.add_format({'bg_color': '#5B7553'}))  # PRIMARY_HEX_3
-            row += 1
-        
-        # Add fuel type distribution
-        row += 2
-        worksheet.write(row, 0, "Fuel Type Distribution:", header_format)
-        row += 1
-        
-        sorted_fuel_types = sorted(fuel_types.items(), key=lambda x: x[1], reverse=True)
-        for fuel_type, count in sorted_fuel_types:
-            worksheet.write(row, 0, fuel_type)
-            worksheet.write(row, 1, count)
-            # Add simple bar using cell background
-            for i in range(min(count, 10)):
-                worksheet.write(row, 2 + i, "", workbook.add_format({'bg_color': '#C45911'}))  # SECONDARY_HEX_1
-            row += 1
-        
-        # Add MPG stats
-        row += 2
-        worksheet.write(row, 0, "MPG Statistics:", header_format)
-        row += 1
-        
-        if mpg_values:
-            avg_mpg = sum(mpg_values) / len(mpg_values)
-            min_mpg = min(mpg_values)
-            max_mpg = max(mpg_values)
-            
-            worksheet.write(row, 0, "Average MPG:")
-            worksheet.write(row, 1, avg_mpg)
-            row += 1
-            
-            worksheet.write(row, 0, "Minimum MPG:")
-            worksheet.write(row, 1, min_mpg)
-            row += 1
-            
-            worksheet.write(row, 0, "Maximum MPG:")
-            worksheet.write(row, 1, max_mpg)
-            row += 1
-        else:
-            worksheet.write(row, 0, "No MPG data available")
-            row += 1
-        
-        # Add CO2 stats
-        row += 2
-        worksheet.write(row, 0, "CO2 Emissions Statistics:", header_format)
-        row += 1
-        
-        if co2_values:
-            avg_co2 = sum(co2_values) / len(co2_values)
-            min_co2 = min(co2_values)
-            max_co2 = max(co2_values)
-            
-            worksheet.write(row, 0, "Average CO2 (g/mile):")
-            worksheet.write(row, 1, avg_co2)
-            row += 1
-            
-            worksheet.write(row, 0, "Minimum CO2 (g/mile):")
-            worksheet.write(row, 1, min_co2)
-            row += 1
-            
-            worksheet.write(row, 0, "Maximum CO2 (g/mile):")
-            worksheet.write(row, 1, max_co2)
-            row += 1
-        else:
-            worksheet.write(row, 0, "No CO2 data available")
-            row += 1
-    
-    def _create_electrification_sheet(self, workbook, analysis, title_format, header_format, cell_format, number_format):
-        """Create Electrification Analysis sheet."""
-        # Create worksheet
-        worksheet = workbook.add_worksheet("Electrification Analysis")
-        
-        # Add title
-        worksheet.merge_range('A1:F1', "Fleet Electrification Analysis", title_format)
-        
-        # Set column widths
-        worksheet.set_column('A:A', 25)
-        worksheet.set_column('B:F', 15)
-        
-        # Add summary section
-        row = 3
-        worksheet.write(row, 0, "Analysis Parameters:", header_format)
-        row += 1
-        
-        worksheet.write(row, 0, "Gas Price ($/gal):")
-        worksheet.write(row, 1, analysis.gas_price)
-        row += 1
-        
-        worksheet.write(row, 0, "Electricity Price ($/kWh):")
-        worksheet.write(row, 1, analysis.electricity_price)
-        row += 1
-        
-        worksheet.write(row, 0, "EV Efficiency (kWh/mile):")
-        worksheet.write(row, 1, analysis.ev_efficiency)
-        row += 1
-        
-        worksheet.write(row, 0, "Analysis Period (years):")
-        worksheet.write(row, 1, analysis.analysis_period)
-        row += 1
-        
-        worksheet.write(row, 0, "Discount Rate (%):")
-        worksheet.write(row, 1, analysis.discount_rate)
-        row += 1
-        
-        # Add results section
-        row += 2
-        worksheet.write(row, 0, "Analysis Results:", header_format)
-        row += 1
-        
-        worksheet.write(row, 0, "Total CO2 Savings (tons):")
-        worksheet.write(row, 1, analysis.co2_savings)
-        row += 1
-        
-        worksheet.write(row, 0, "Fuel Cost Savings ($):")
-        worksheet.write(row, 1, analysis.fuel_cost_savings)
-        row += 1
-        
-        worksheet.write(row, 0, "Maintenance Savings ($):")
-        worksheet.write(row, 1, analysis.maintenance_savings)
-        row += 1
-        
-        worksheet.write(row, 0, "Total Savings ($):")
-        worksheet.write(row, 1, analysis.total_savings)
-        row += 1
-        
-        worksheet.write(row, 0, "Payback Period (years):")
-        worksheet.write(row, 1, analysis.payback_period)
-        row += 1
-        
-        # Add vehicle results table
-        row += 2
-        worksheet.write(row, 0, "Vehicle-Level Results:", header_format)
-        row += 1
-        
-        # Create headers
-        headers = [
-            "Vehicle", "Annual Mileage", "MPG", "Annual Fuel Savings ($)", 
-            "Lifetime Fuel Savings ($)", "CO2 Reduction (tons)", "Payback Period (years)"
-        ]
-        
-        for col, header in enumerate(headers):
-            worksheet.write(row, col, header, header_format)
-        
-        row += 1
-        
-        # Sort vehicles by savings (if we have the prioritized list)
-        vehicles_to_show = []
-        for vin in analysis.prioritized_vehicles:
-            if vin in analysis.vehicle_results:
-                vehicles_to_show.append((vin, analysis.vehicle_results[vin]))
-        
-        # If no prioritized list, just sort by savings
-        if not vehicles_to_show:
-            vehicles_to_show = sorted(
-                analysis.vehicle_results.items(),
-                key=lambda x: x[1].get("total_npv_savings", 0),
-                reverse=True
-            )
-        
-        # Add data for top vehicles
-        for vin, data in vehicles_to_show:
-            display_name = data.get("display_name", vin)
-            annual_mileage = data.get("annual_mileage", 0)
-            mpg = data.get("mpg", 0)
-            annual_savings = data.get("annual_fuel_savings", 0)
-            total_savings = data.get("total_fuel_savings", 0)
-            co2_reduction = data.get("total_co2_reduction", 0)
-            
-            # Calculate payback (assuming $15k premium)
-            ev_premium = 15000
-            annual_total_savings = annual_savings + data.get("annual_maintenance_savings", 0)
-            payback = ev_premium / annual_total_savings if annual_total_savings > 0 else float('inf')
-            
-            worksheet.write(row, 0, display_name, cell_format)
-            worksheet.write(row, 1, annual_mileage, number_format)
-            worksheet.write(row, 2, mpg, number_format)
-            worksheet.write(row, 3, annual_savings, number_format)
-            worksheet.write(row, 4, total_savings, number_format)
-            worksheet.write(row, 5, co2_reduction, number_format)
-            
-            if payback == float('inf'):
-                worksheet.write(row, 6, "N/A", cell_format)
-            else:
-                worksheet.write(row, 6, payback, number_format)
-            
-            row += 1
-    
     def _create_charging_sheet(self, workbook, charging, vehicles, title_format, header_format, cell_format, number_format):
         """Create Infrastructure & Action Items sheet.
 
@@ -2108,96 +1854,6 @@ class ExcelReportGenerator(ReportGenerator):
             chart.set_legend({'none': True})
             chart.set_size({'width': 560, 'height': 280})
             ws.insert_chart(header_row, 10, chart)
-
-    def _create_summary_dashboard_sheet(self, workbook, vehicles, analysis, charging, emissions, title_format, header_format, cell_format, number_format):
-        """Create Summary Dashboard sheet with KPI reference cells."""
-        ws = workbook.add_worksheet("Summary Dashboard")
-        kpi_title_fmt = workbook.add_format({
-            'bold': True, 'font_size': 11, 'bg_color': '#2C3E50',
-            'font_color': 'white', 'border': 1, 'align': 'center'
-        })
-        kpi_value_fmt = workbook.add_format({
-            'bold': True, 'font_size': 16, 'align': 'center',
-            'border': 1, 'num_format': '$#,##0'
-        })
-        kpi_text_fmt = workbook.add_format({
-            'bold': True, 'font_size': 16, 'align': 'center', 'border': 1
-        })
-
-        ws.merge_range('A1:F1', "Fleet Electrification — Executive Summary Dashboard", title_format)
-        ws.set_column(0, 5, 22)
-
-        # Row 3-4: Fleet KPIs
-        fleet_kpis = [
-            ("Fleet Size", str(len(vehicles)), False),
-            ("Avg MPG", f"{sum(v.fuel_economy.combined_mpg or 0 for v in vehicles) / max(1, sum(1 for v in vehicles if v.fuel_economy.combined_mpg)):,.1f}", False),
-        ]
-
-        if analysis:
-            fleet_kpis.extend([
-                ("Annual Savings", analysis.total_savings, True),
-                ("CO₂ Reduction", f"{analysis.co2_savings:,.1f} MT", False),
-                ("Payback Period", f"{analysis.payback_period:.1f} yr", False),
-            ])
-
-        if charging:
-            fleet_kpis.append(
-                ("Infrastructure Cost", charging.estimated_installation_cost, True)
-            )
-
-        for col, (title, value, is_currency) in enumerate(fleet_kpis):
-            ws.write(2, col, title, kpi_title_fmt)
-            if is_currency:
-                ws.write(3, col, value, kpi_value_fmt)
-            else:
-                ws.write(3, col, str(value), kpi_text_fmt)
-
-        # Row 6+: Breakdown tables
-        row = 6
-        if emissions and emissions.by_department:
-            ws.write(row, 0, "Emissions by Department", header_format)
-            ws.write(row, 1, "MT CO2e", header_format)
-            row += 1
-            for dept, em in sorted(emissions.by_department.items(), key=lambda x: x[1], reverse=True):
-                ws.write(row, 0, dept, cell_format)
-                ws.write(row, 1, em, number_format)
-                row += 1
-            row += 1
-
-        # ACF breakdown
-        acf_counts = {}
-        for v in vehicles:
-            code = v.custom_fields.get('ACF Category', '')
-            if code:
-                acf_counts[code] = acf_counts.get(code, 0) + 1
-
-        if acf_counts:
-            ws.write(row, 0, "ACF Classification", header_format)
-            ws.write(row, 1, "Count", header_format)
-            row += 1
-            for cat, count in sorted(acf_counts.items()):
-                ws.write(row, 0, cat, cell_format)
-                ws.write(row, 1, count, cell_format)
-                row += 1
-            row += 1
-
-        # EV year distribution
-        year_counts = {}
-        for v in vehicles:
-            yr = v.custom_fields.get('Proposed EV Year', '')
-            if yr and yr not in ('N/A', 'Exempt'):
-                year_counts[yr] = year_counts.get(yr, 0) + 1
-
-        if year_counts:
-            ws.write(row, 0, "Replacement Year", header_format)
-            ws.write(row, 1, "Vehicles", header_format)
-            row += 1
-            for yr, count in sorted(year_counts.items()):
-                ws.write(row, 0, yr, cell_format)
-                ws.write(row, 1, count, cell_format)
-                row += 1
-
-
 
 ###############################################################################
 # PDF Export — REMOVED (Phase 5 Fix 40 / Phase 13 Fix G)

--- a/data/config.json
+++ b/data/config.json
@@ -1,5 +1,5 @@
 {
-    "window_size": "1400x900",
+    "window_size": "1400x800",
     "max_threads": 10,
     "visible_columns": [
         "VIN",

--- a/data/processing_history.json
+++ b/data/processing_history.json
@@ -1,45 +1,5 @@
 [
   {
-    "timestamp": "2025-09-09T14:45:09.686901",
-    "input_file": "/Users/jacksonflynn/Documents/Optony/Seaside/seaside_vins.csv",
-    "output_file": "/Users/jacksonflynn/Documents/Optony/Seaside/processed_seaside_vins.csv",
-    "max_threads": 8,
-    "skip_existing": true,
-    "input_filename": "seaside_vins.csv"
-  },
-  {
-    "timestamp": "2025-09-11T14:35:39.340724",
-    "input_file": "/Users/jacksonflynn/Documents/Claude SMCCCD/SMCCCD VINs.csv",
-    "output_file": "/Users/jacksonflynn/Documents/Claude SMCCCD/SMCCCD VINs_fleet_analysis_20250911_143539.csv",
-    "max_threads": 8,
-    "skip_existing": true,
-    "input_filename": "SMCCCD VINs.csv"
-  },
-  {
-    "timestamp": "2025-09-16T16:49:26.061455",
-    "input_file": "/Users/jacksonflynn/Downloads/cabrilloUSD_vins.csv",
-    "output_file": "/Users/jacksonflynn/Downloads/cabrilloUSD_vins_fleet_analysis_20250916_164920.csv",
-    "max_threads": 8,
-    "skip_existing": true,
-    "input_filename": "cabrilloUSD_vins.csv"
-  },
-  {
-    "timestamp": "2025-09-19T12:51:21.088437",
-    "input_file": "/Users/jacksonflynn/Downloads/cabrilloUSD_vins.csv",
-    "output_file": "/Users/jacksonflynn/Downloads/cabrilloUSD_vins_fleet_analysis_20250919_125121.csv",
-    "max_threads": 8,
-    "skip_existing": true,
-    "input_filename": "cabrilloUSD_vins.csv"
-  },
-  {
-    "timestamp": "2025-09-19T12:56:22.268418",
-    "input_file": "/Users/jacksonflynn/Documents/Optony/Seaside/seaside_vins.csv",
-    "output_file": "/Users/jacksonflynn/Documents/Optony/Seaside/seaside_vins_fleet_analysis_20250919_125622.csv",
-    "max_threads": 8,
-    "skip_existing": true,
-    "input_filename": "seaside_vins.csv"
-  },
-  {
     "timestamp": "2025-09-26T15:38:56.629107",
     "input_file": "/Users/jacksonflynn/Documents/Optony/Seaside/seaside_vins.csv",
     "output_file": "/Users/jacksonflynn/Documents/Optony/Seaside/seaside_vins_fleet_analysis_20250926_153856.csv",
@@ -78,5 +38,45 @@
     "max_threads": 8,
     "skip_existing": true,
     "input_filename": "seaside_vins.csv"
+  },
+  {
+    "timestamp": "2026-06-03T10:40:05.930733",
+    "input_file": "/Users/jacksonflynn/Downloads/BAAD VINs - Sheet1.csv",
+    "output_file": "/Users/jacksonflynn/Downloads/BAAD VINs - Sheet1_fleet_analysis_20260603_103955.csv",
+    "max_threads": 8,
+    "skip_existing": true,
+    "input_filename": "BAAD VINs - Sheet1.csv"
+  },
+  {
+    "timestamp": "2026-06-03T12:39:17.937203",
+    "input_file": "/Users/jacksonflynn/Downloads/BAAD VINs - Sheet1.csv",
+    "output_file": "/Users/jacksonflynn/Downloads/BAAD VINs - Sheet1_fleet_analysis_20260603_123841.csv",
+    "max_threads": 8,
+    "skip_existing": true,
+    "input_filename": "BAAD VINs - Sheet1.csv"
+  },
+  {
+    "timestamp": "2026-06-03T13:01:51.328050",
+    "input_file": "/Users/jacksonflynn/Downloads/BAAD VINs - Sheet1-2.csv",
+    "output_file": "/Users/jacksonflynn/Downloads/BAAD VINs - Sheet1-2_fleet_analysis_20260603_130145.csv",
+    "max_threads": 8,
+    "skip_existing": true,
+    "input_filename": "BAAD VINs - Sheet1-2.csv"
+  },
+  {
+    "timestamp": "2026-06-04T15:08:56.417770",
+    "input_file": "/Users/jacksonflynn/Downloads/BAAD VINs - Sheet1-2.csv",
+    "output_file": "/Users/jacksonflynn/Downloads/BAAD VINs - Sheet1-2_fleet_analysis_20260604_150854.csv",
+    "max_threads": 8,
+    "skip_existing": true,
+    "input_filename": "BAAD VINs - Sheet1-2.csv"
+  },
+  {
+    "timestamp": "2026-06-10T12:43:12.561859",
+    "input_file": "/Users/jacksonflynn/Downloads/RCSD VINs - Sheet1.csv",
+    "output_file": "/Users/jacksonflynn/Downloads/RCSD VINs - Sheet1_fleet_analysis_20260610_124308.csv",
+    "max_threads": 8,
+    "skip_existing": true,
+    "input_filename": "RCSD VINs - Sheet1.csv"
   }
 ]

--- a/data/project_io.py
+++ b/data/project_io.py
@@ -1,0 +1,205 @@
+"""
+project_io.py
+
+Save and load Fleet Electrification Analyzer project files (.fea).
+
+A .fea file is a JSON document containing the full Fleet state — all
+FleetVehicle records (including VehicleIdentification, FuelEconomyData,
+ACF codes, EV year assignments, and custom_fields) plus optional
+scenario_results from the last analysis run.
+
+Loading a project reconstructs the Fleet in memory and bypasses the
+VIN-processing pipeline entirely.
+"""
+
+import copy
+import datetime
+import json
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+from data.models import Fleet, FleetVehicle, FuelEconomyData, VehicleIdentification
+
+logger = logging.getLogger(__name__)
+
+PROJECT_VERSION = 1
+FILE_EXTENSION = ".fea"
+
+
+# ---------------------------------------------------------------------------
+# JSON encoder / decoder helpers
+# ---------------------------------------------------------------------------
+
+class _DatetimeEncoder(json.JSONEncoder):
+    """Serialize datetime.date and datetime.datetime as tagged dicts."""
+
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, datetime.datetime):
+            return {"__type__": "datetime", "value": obj.isoformat()}
+        if isinstance(obj, datetime.date):
+            return {"__type__": "date", "value": obj.isoformat()}
+        return super().default(obj)
+
+
+def _datetime_hook(obj: Dict) -> Any:
+    """Reconstruct datetime objects from tagged dicts produced by _DatetimeEncoder."""
+    t = obj.get("__type__")
+    if t == "datetime":
+        return datetime.datetime.fromisoformat(obj["value"])
+    if t == "date":
+        return datetime.date.fromisoformat(obj["value"])
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+def _serialize_vehicle(v: FleetVehicle) -> Dict:
+    """Convert a FleetVehicle to a plain JSON-serializable dict.
+
+    commercial_specs is intentionally excluded — it holds scraped specs that
+    can be re-fetched and is not a plain dataclass on all code paths.
+    """
+    import dataclasses
+
+    v_copy = copy.copy(v)
+    v_copy.commercial_specs = None  # exclude — not reliably serializable
+    return dataclasses.asdict(v_copy)
+
+
+# ---------------------------------------------------------------------------
+# Deserialization
+# ---------------------------------------------------------------------------
+
+def _coerce_date(value: Any) -> Optional[datetime.date]:
+    if value is None:
+        return None
+    if isinstance(value, datetime.date):
+        return value
+    if isinstance(value, str) and value:
+        return datetime.date.fromisoformat(value)
+    return None
+
+
+def _coerce_datetime(value: Any) -> Optional[datetime.datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime.datetime):
+        return value
+    if isinstance(value, str) and value:
+        return datetime.datetime.fromisoformat(value)
+    return None
+
+
+def _deserialize_vehicle_id(d: Dict) -> VehicleIdentification:
+    valid = set(VehicleIdentification.__dataclass_fields__)
+    return VehicleIdentification(**{k: v for k, v in d.items() if k in valid})
+
+
+def _deserialize_fuel_economy(d: Dict) -> FuelEconomyData:
+    valid = set(FuelEconomyData.__dataclass_fields__)
+    return FuelEconomyData(**{k: v for k, v in d.items() if k in valid})
+
+
+def _deserialize_vehicle(d: Dict) -> FleetVehicle:
+    vehicle_id = _deserialize_vehicle_id(d.get("vehicle_id") or {})
+    fuel_economy = _deserialize_fuel_economy(d.get("fuel_economy") or {})
+
+    # Date/datetime fields require explicit coercion (asdict leaves them as
+    # tagged dicts after _datetime_hook runs, or raw ISO strings on older files)
+    acquisition_date = _coerce_date(d.get("acquisition_date"))
+    retire_date = _coerce_date(d.get("retire_date"))
+    last_quality_check = _coerce_datetime(d.get("last_quality_check"))
+
+    skip = {
+        "vehicle_id", "fuel_economy",
+        "acquisition_date", "retire_date", "last_quality_check",
+        "commercial_specs",
+    }
+    valid = set(FleetVehicle.__dataclass_fields__)
+    scalar_fields = {k: v for k, v in d.items() if k in valid and k not in skip}
+
+    return FleetVehicle(
+        vehicle_id=vehicle_id,
+        fuel_economy=fuel_economy,
+        acquisition_date=acquisition_date,
+        retire_date=retire_date,
+        last_quality_check=last_quality_check,
+        commercial_specs=None,
+        **scalar_fields,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def save_project(
+    path: str,
+    fleet: Fleet,
+    scenario_results: Optional[Dict] = None,
+) -> None:
+    """Write the Fleet (and optional scenario_results) to a .fea JSON file.
+
+    Args:
+        path:             Destination file path (should end in .fea).
+        fleet:            Fleet object to persist.
+        scenario_results: Dict returned by compare_scenarios(), or None.
+    """
+    payload = {
+        "version": PROJECT_VERSION,
+        "fleet": {
+            "name": fleet.name,
+            "notes": fleet.notes,
+            "fleet_type": fleet.fleet_type,
+            "max_vehicles_per_year": fleet.max_vehicles_per_year,
+            "creation_date": fleet.creation_date.isoformat() if fleet.creation_date else None,
+            "last_modified": datetime.datetime.now().isoformat(),
+            "vehicles": [_serialize_vehicle(v) for v in fleet.vehicles],
+        },
+        "scenario_results": scenario_results,
+    }
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, cls=_DatetimeEncoder)
+    logger.info("Project saved to %s (%d vehicles)", path, len(fleet.vehicles))
+
+
+def load_project(path: str) -> Tuple[Fleet, Optional[Dict]]:
+    """Read a .fea file and reconstruct the Fleet.
+
+    Returns:
+        (fleet, scenario_results) — scenario_results is None when no analysis
+        had been run before saving.
+
+    Raises:
+        ValueError: If the file version is unsupported.
+        json.JSONDecodeError / IOError: On corrupt or missing file.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh, object_hook=_datetime_hook)
+
+    version = data.get("version", 1)
+    if version > PROJECT_VERSION:
+        raise ValueError(
+            f"Project file version {version} is newer than this app supports "
+            f"(max {PROJECT_VERSION}). Please upgrade the application."
+        )
+
+    fd = data["fleet"]
+    vehicles = [_deserialize_vehicle(vd) for vd in fd.get("vehicles", [])]
+
+    creation_date = _coerce_datetime(fd.get("creation_date")) or datetime.datetime.now()
+
+    fleet = Fleet(
+        name=fd.get("name", "Loaded Fleet"),
+        notes=fd.get("notes", ""),
+        fleet_type=fd.get("fleet_type", "hpf"),
+        max_vehicles_per_year=fd.get("max_vehicles_per_year", 0),
+        creation_date=creation_date,
+        last_modified=datetime.datetime.now(),
+        vehicles=vehicles,
+    )
+
+    logger.info("Project loaded from %s (%d vehicles)", path, len(vehicles))
+    return fleet, data.get("scenario_results")

--- a/powerpoint_export.py
+++ b/powerpoint_export.py
@@ -505,12 +505,12 @@ def _add_acf_electrification_chart(
 
     current_year = datetime.datetime.now().year
 
-    # Plain-English labels matching the user-built deck
+    # Plain-English labels for the ACF composition pie
     ACF_LABELS = {
-        "A": "Light Duty (Excluded)",
-        "B": "Medium or Heavy Duty",
-        "C": "Medium or Heavy Duty Potentially Exempted",
-        "D": "Emergency Vehicles (Excluded)",
+        "A": "Light Duty Vehicles (Excluded from ACF)",
+        "B": "Medium or Heavy-Duty Vehicles (Subject to ACF)",
+        "C": "Body-Type Exempt Vehicles (Excluded from ACF)",
+        "D": "Emergency Vehicles (Excluded from ACF)",
     }
     # Display order: B first (mandate-subject), then exempt categories
     ACF_ORDER = ["B", "A", "C", "D"]
@@ -612,10 +612,10 @@ def _add_purchase_schedule_chart(
         return False
 
     SERIES_DEFS = [
-        ("A", "Light Duty (Excluded from ACF Regulations)",           "#4472C4"),
-        ("B", "Medium or Heavy Duty",                                  SECONDARY_HEX_1),
-        ("C", "M/HD Vehicles Potentially Exempted from ACF",           "#FFC000"),
-        ("D", "Emergency Vehicles (Excluded from ACF Regulations)",    "#808080"),
+        ("A", "Light Duty Vehicles (Excluded from ACF)",               "#4472C4"),
+        ("B", "Medium or Heavy-Duty Vehicles (Subject to ACF)",        SECONDARY_HEX_1),
+        ("C", "Body-Type Exempt Vehicles (Excluded from ACF)",         "#FFC000"),
+        ("D", "Emergency Vehicles (Excluded from ACF)",                "#808080"),
     ]
 
     current_year = datetime.datetime.now().year
@@ -706,11 +706,11 @@ def _add_milestone_option_chart(
         return False
 
     SERIES_DEFS = [
-        ("A",       "Light Duty (Excluded from ACF Regulations)",         "#4472C4"),
-        ("B_GRP1",  "Milestone Group 1 (Class 2b\u20134)",                "#70AD47"),
-        ("B_GRP2",  "Milestone Group 2 (Class 5\u20138a/8b)",             "#375623"),
-        ("C",       "M/HD Vehicles Potentially Exempted from ACF",         "#FFC000"),
-        ("D",       "Emergency Vehicles (Excluded from ACF Regulations)", "#808080"),
+        ("A",       "Light Duty Vehicles (Excluded from ACF)",             "#4472C4"),
+        ("B_GRP1",  "M/HD Subject to ACF \u2014 Milestone Group 1 (Class 2b\u20134)",   "#70AD47"),
+        ("B_GRP2",  "M/HD Subject to ACF \u2014 Milestone Group 2 (Class 5\u20138a/8b)", "#375623"),
+        ("C",       "Body-Type Exempt Vehicles (Excluded from ACF)",       "#FFC000"),
+        ("D",       "Emergency Vehicles (Excluded from ACF)",              "#808080"),
     ]
 
     start_year = 2026

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 matplotlib>=3.7.1
 numpy>=1.24.3
 pandas>=2.0.0
-tkinter>=8.6
 pillow>=9.5.0
 seaborn>=0.12.2
 scipy>=1.10.1

--- a/tests/test_excel_report.py
+++ b/tests/test_excel_report.py
@@ -1,0 +1,186 @@
+"""
+test_excel_report.py
+
+Smoke + structural assertions for the Excel report v2 (cover + 6 sheets).
+Verifies sheet set/order, the canonical Cover assumptions block, that the old
+$15,000 hardcoded EV premium is gone, incentive net <= gross, and the scenario
+comparison table.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+openpyxl = pytest.importorskip("openpyxl")
+from openpyxl import load_workbook
+
+from data.models import (
+    FleetVehicle, VehicleIdentification, FuelEconomyData, Fleet,
+    ElectrificationAnalysis, ChargingAnalysis, EmissionsInventory,
+)
+from analysis.reports import ExcelReportGenerator, cover_aref, COVER_SHEET_NAME, _ASSUMPTION_ROW
+
+
+def _vehicle(i, acf="B"):
+    vin = "1FTAA" + str(i).zfill(12)
+    v = FleetVehicle(vin=vin)
+    v.vehicle_id = VehicleIdentification(
+        vin=vin, year="2017", make="Ford", model="F-350",
+        fuel_type="Diesel", gvwr="Class 6")
+    v.fuel_economy = FuelEconomyData(combined_mpg=12)
+    v.processing_success = True
+    v.annual_mileage = 15000
+    v.odometer = 90000
+    v.match_confidence = 80
+    v.custom_fields.update({
+        "_acf_code": acf, "ACF Category": acf,
+        "_ev_purchase_price": 90000, "_payback_years": 8.0,
+        "Proposed EV Year": str(2028 + (i % 3)),
+    })
+    return v
+
+
+def _full_analysis(vehicles):
+    an = ElectrificationAnalysis(fleet_name="RCSD")
+    an.gas_price = 3.5
+    an.electricity_price = 0.13
+    an.ev_efficiency = 0.3
+    an.discount_rate = 5.0
+    an.analysis_period = 12
+    an.total_savings = 200000
+    an.payback_period = 8.0
+    an.co2_savings = 60
+    an.fleet_cash_flows = [
+        {"year": y, "gas_price": 3.5, "electricity_price": 0.13} for y in range(1, 13)]
+    an.vehicle_results = {
+        v.vin: {"display_name": f"veh {i}", "annual_mileage": 15000, "mpg": 12,
+                "annual_fuel_savings": 3000, "total_fuel_savings": 36000,
+                "total_co2_reduction": 10, "total_npv_savings": 20000}
+        for i, v in enumerate(vehicles)}
+    an.prioritized_vehicles = [v.vin for v in vehicles]
+    return an
+
+
+@pytest.fixture
+def workbook_path():
+    vehicles = [_vehicle(i, acf=("A" if i == 0 else "B")) for i in range(6)]
+    fleet = Fleet(name="RCSD")
+    fleet.vehicles = vehicles
+    fleet.max_vehicles_per_year = 2
+
+    an = _full_analysis(vehicles)
+    ch = ChargingAnalysis(fleet_name="RCSD")
+    ch.level2_chargers_needed = 8
+    ch.dcfc_chargers_needed = 3
+    ch.estimated_installation_cost = 200000
+    em = EmissionsInventory(fleet_name="RCSD")
+    em.total_emissions = 400
+    em.by_fuel_type = {"Diesel": 400}
+
+    fd, path = tempfile.mkstemp(suffix=".xlsx")
+    os.close(fd)
+    ok = ExcelReportGenerator(path).generate(
+        fleet=fleet, analysis=an, charging=ch, emissions=em, state_code="CA")
+    assert ok
+    yield path
+    os.remove(path)
+
+
+EXPECTED_SHEETS = [
+    "Cover & Methodology",
+    "Vehicle Data",
+    "Fleet Overview",
+    "TCO & Financials",
+    "Replacement & Capital Plan",
+    "Emissions & Scenarios",
+    "Infrastructure & Action Items",
+]
+
+
+def test_sheet_set_and_order(workbook_path):
+    wb = load_workbook(workbook_path)
+    assert wb.sheetnames == EXPECTED_SHEETS
+
+
+def test_cover_has_canonical_assumptions(workbook_path):
+    wb = load_workbook(workbook_path)
+    cov = wb[COVER_SHEET_NAME]
+    # Gas price seed lives at the mapped canonical row, column B.
+    gas_row = _ASSUMPTION_ROW["gas_price"]
+    assert cov.cell(gas_row, 2).value == pytest.approx(3.5)
+    # analysis_period is the last assumption
+    period_row = _ASSUMPTION_ROW["analysis_period"]
+    assert cov.cell(period_row, 2).value == pytest.approx(12)
+
+
+def test_tco_assumptions_mirror_cover(workbook_path):
+    wb = load_workbook(workbook_path)
+    tco = wb["TCO & Financials"]
+    # B4 should be a formula pointing at the Cover gas-price cell.
+    assert tco["B4"].value == "=" + cover_aref("gas_price")
+
+
+def test_no_hardcoded_15000_premium():
+    """The old Electrification payback used a flat `ev_premium = 15000`; ensure the
+    code no longer hardcodes an EV premium for payback."""
+    import analysis.reports as reports_mod
+    src = open(reports_mod.__file__, encoding="utf-8").read()
+    assert "ev_premium" not in src, "Old hardcoded EV-premium payback logic still present"
+
+
+def test_per_vehicle_payback_uses_real_value(workbook_path):
+    wb = load_workbook(workbook_path)
+    tco = wb["TCO & Financials"]
+    # Find the per-vehicle savings header, then check a payback cell == 8.0
+    found_header = False
+    for r in range(1, tco.max_row + 1):
+        if tco.cell(r, 1).value == "Per-Vehicle Savings Detail":
+            found_header = True
+            # header row is r+1, data starts r+2
+            assert tco.cell(r + 2, 7).value == pytest.approx(8.0)
+            break
+    assert found_header
+
+
+def test_incentive_net_not_greater_than_gross(workbook_path):
+    wb = load_workbook(workbook_path)
+    tco = wb["TCO & Financials"]
+    for r in range(1, tco.max_row + 1):
+        if tco.cell(r, 1).value == "TOTAL":
+            gross = tco.cell(r, 3).value
+            net = tco.cell(r, 6).value
+            if isinstance(gross, (int, float)) and isinstance(net, (int, float)):
+                assert net <= gross
+            break
+
+
+def test_scenario_comparison_present(workbook_path):
+    wb = load_workbook(workbook_path)
+    es = wb["Emissions & Scenarios"]
+    names = {es.cell(r, 1).value for r in range(1, es.max_row + 1)}
+    assert "Scenario Comparison (time-based presets)" in names
+
+
+def test_action_items_present(workbook_path):
+    wb = load_workbook(workbook_path)
+    ia = wb["Infrastructure & Action Items"]
+    labels = {ia.cell(r, 1).value for r in range(1, ia.max_row + 1)}
+    assert "Data Gaps & Action Items" in labels
+
+
+def test_generates_with_minimal_data():
+    """A bare fleet (no analysis/charging/emissions) still yields a valid file."""
+    v = _vehicle(0)
+    fleet = Fleet(name="RCSD")
+    fleet.vehicles = [v]
+    fd, path = tempfile.mkstemp(suffix=".xlsx")
+    os.close(fd)
+    try:
+        assert ExcelReportGenerator(path).generate(fleet=fleet)
+        wb = load_workbook(path)
+        # Cover, Vehicle Data, Fleet Overview, Replacement, Infrastructure always present
+        assert "Cover & Methodology" in wb.sheetnames
+        assert "Infrastructure & Action Items" in wb.sheetnames
+    finally:
+        os.remove(path)

--- a/tests/test_project_io.py
+++ b/tests/test_project_io.py
@@ -1,0 +1,211 @@
+"""
+Tests for data/project_io.py — project save/load (.fea files).
+
+Covers round-trip serialization of Fleet objects including nested
+VehicleIdentification, FuelEconomyData, custom_fields (ACF codes,
+EV year assignments), datetime fields, and scenario_results.
+"""
+
+import datetime
+import json
+import os
+import sys
+import tempfile
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from tests.conftest import make_fleet_vehicle
+from data.models import Fleet
+from data.project_io import load_project, save_project
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fleet(num_vehicles: int = 3, fleet_type: str = "hpf") -> Fleet:
+    vehicles = []
+    for i in range(num_vehicles):
+        vin = f"1HGBH41JXM{i:07d}"
+        v = make_fleet_vehicle(
+            vin=vin,
+            vid_overrides={"vin": vin, "year": str(2015 + i), "make": "Ford", "model": "F-150"},
+            fuel_overrides={"combined_mpg": 20.0 + i, "co2_primary": 400.0},
+            custom_fields={
+                "_acf_code": "B",
+                "ACF Category": "Category B — Mandate-Subject",
+                "Proposed EV Year": str(2028 + i),
+                "_ev_year_overridden": False,
+            },
+            acquisition_date=datetime.date(2015 + i, 6, 1),
+            odometer=float(50_000 + i * 10_000),
+        )
+        vehicles.append(v)
+    return Fleet(
+        name="Test Fleet",
+        vehicles=vehicles,
+        fleet_type=fleet_type,
+        max_vehicles_per_year=5,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests
+# ---------------------------------------------------------------------------
+
+class TestRoundTrip:
+    def test_basic_round_trip(self, tmp_path):
+        fleet = _make_fleet(3)
+        path = str(tmp_path / "test.fea")
+        save_project(path, fleet)
+        loaded_fleet, scenario_results = load_project(path)
+
+        assert len(loaded_fleet.vehicles) == 3
+        assert loaded_fleet.name == fleet.name
+        assert loaded_fleet.fleet_type == fleet.fleet_type
+        assert loaded_fleet.max_vehicles_per_year == fleet.max_vehicles_per_year
+        assert scenario_results is None
+
+    def test_vehicle_fields_preserved(self, tmp_path):
+        fleet = _make_fleet(1)
+        original = fleet.vehicles[0]
+        path = str(tmp_path / "test.fea")
+        save_project(path, fleet)
+        loaded, _ = load_project(path)
+        v = loaded.vehicles[0]
+
+        assert v.vin == original.vin
+        assert v.vehicle_id.year == original.vehicle_id.year
+        assert v.vehicle_id.make == original.vehicle_id.make
+        assert v.vehicle_id.model == original.vehicle_id.model
+        assert v.fuel_economy.combined_mpg == original.fuel_economy.combined_mpg
+        assert v.odometer == original.odometer
+
+    def test_acf_codes_preserved(self, tmp_path):
+        fleet = _make_fleet(2)
+        path = str(tmp_path / "test.fea")
+        save_project(path, fleet)
+        loaded, _ = load_project(path)
+
+        for orig, v in zip(fleet.vehicles, loaded.vehicles):
+            assert v.custom_fields.get("_acf_code") == orig.custom_fields["_acf_code"]
+            assert v.custom_fields.get("Proposed EV Year") == orig.custom_fields["Proposed EV Year"]
+
+    def test_datetime_date_preserved(self, tmp_path):
+        fleet = _make_fleet(1)
+        fleet.vehicles[0].acquisition_date = datetime.date(2019, 3, 15)
+        path = str(tmp_path / "test.fea")
+        save_project(path, fleet)
+        loaded, _ = load_project(path)
+        assert loaded.vehicles[0].acquisition_date == datetime.date(2019, 3, 15)
+
+    def test_last_quality_check_datetime_preserved(self, tmp_path):
+        fleet = _make_fleet(1)
+        dt = datetime.datetime(2025, 1, 20, 14, 30, 0)
+        fleet.vehicles[0].last_quality_check = dt
+        path = str(tmp_path / "test.fea")
+        save_project(path, fleet)
+        loaded, _ = load_project(path)
+        assert loaded.vehicles[0].last_quality_check == dt
+
+    def test_none_dates_preserved(self, tmp_path):
+        fleet = _make_fleet(1)
+        fleet.vehicles[0].acquisition_date = None
+        fleet.vehicles[0].last_quality_check = None
+        path = str(tmp_path / "test.fea")
+        save_project(path, fleet)
+        loaded, _ = load_project(path)
+        assert loaded.vehicles[0].acquisition_date is None
+        assert loaded.vehicles[0].last_quality_check is None
+
+    def test_scenario_results_round_trip(self, tmp_path):
+        fleet = _make_fleet(2)
+        fake_scenario_results = {
+            "scenarios": [{"name": "Aggressive 2030", "vehicles_per_year": {2026: 1}}],
+            "all_years": [2026, 2027, 2028],
+            "best_roi": "Aggressive 2030",
+        }
+        path = str(tmp_path / "test.fea")
+        save_project(path, fleet, scenario_results=fake_scenario_results)
+        _, scenario_results = load_project(path)
+
+        assert scenario_results is not None
+        assert scenario_results["best_roi"] == "Aggressive 2030"
+        assert scenario_results["all_years"] == [2026, 2027, 2028]
+
+    def test_fleet_type_options(self, tmp_path):
+        for fleet_type in ("hpf", "non_hpf", "state_agency"):
+            fleet = _make_fleet(1, fleet_type=fleet_type)
+            path = str(tmp_path / f"test_{fleet_type}.fea")
+            save_project(path, fleet)
+            loaded, _ = load_project(path)
+            assert loaded.fleet_type == fleet_type
+
+    def test_empty_fleet(self, tmp_path):
+        fleet = Fleet(name="Empty")
+        path = str(tmp_path / "empty.fea")
+        save_project(path, fleet)
+        loaded, _ = load_project(path)
+        assert loaded.vehicles == []
+        assert loaded.name == "Empty"
+
+    def test_file_is_valid_json(self, tmp_path):
+        fleet = _make_fleet(1)
+        path = str(tmp_path / "test.fea")
+        save_project(path, fleet)
+        with open(path) as f:
+            data = json.load(f)
+        assert data["version"] == 1
+        assert "fleet" in data
+        assert len(data["fleet"]["vehicles"]) == 1
+
+    def test_large_fleet(self, tmp_path):
+        fleet = _make_fleet(50)
+        path = str(tmp_path / "large.fea")
+        save_project(path, fleet)
+        loaded, _ = load_project(path)
+        assert len(loaded.vehicles) == 50
+
+    def test_custom_fields_unicode(self, tmp_path):
+        fleet = _make_fleet(1)
+        fleet.vehicles[0].custom_fields["Department"] = "Public Works — Sanitation"
+        path = str(tmp_path / "unicode.fea")
+        save_project(path, fleet)
+        loaded, _ = load_project(path)
+        assert loaded.vehicles[0].custom_fields["Department"] == "Public Works — Sanitation"
+
+    def test_ev_year_override_flag_preserved(self, tmp_path):
+        fleet = _make_fleet(1)
+        fleet.vehicles[0].custom_fields["_ev_year_overridden"] = True
+        path = str(tmp_path / "override.fea")
+        save_project(path, fleet)
+        loaded, _ = load_project(path)
+        assert loaded.vehicles[0].custom_fields.get("_ev_year_overridden") is True
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises((FileNotFoundError, IOError)):
+            load_project(str(tmp_path / "nonexistent.fea"))
+
+    def test_corrupt_json_raises(self, tmp_path):
+        path = str(tmp_path / "corrupt.fea")
+        with open(path, "w") as f:
+            f.write("not valid json {{{")
+        with pytest.raises(json.JSONDecodeError):
+            load_project(path)
+
+    def test_future_version_raises(self, tmp_path):
+        path = str(tmp_path / "future.fea")
+        with open(path, "w") as f:
+            json.dump({"version": 999, "fleet": {"vehicles": [], "name": "x"}}, f)
+        with pytest.raises(ValueError, match="newer than this app"):
+            load_project(path)

--- a/ui/analysis_panel.py
+++ b/ui/analysis_panel.py
@@ -13,6 +13,7 @@ import datetime
 import logging
 import threading
 import subprocess
+import warnings
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 from typing import Dict, List, Any, Optional, Callable, Tuple
@@ -23,6 +24,7 @@ import matplotlib
 matplotlib.use("TkAgg")
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from matplotlib.ticker import MaxNLocator
 
 try:
     from PIL import Image as _PILImage, ImageTk as _ImageTk
@@ -86,11 +88,31 @@ ACF_COLORS = {
 
 # Plain-English labels for ACF category codes (shared with timeline_panel)
 ACF_LABELS = {
-    "ZEV": "Already ZEV",
-    "A":   "Light-Duty (Exempt)",
-    "B":   "Mandate-Subject",
-    "C":   "Body-Type Exempt",
+    "ZEV": "Already Zero-Emission",
+    "A":   "Light Duty Vehicles (Excluded from ACF)",
+    "B":   "Medium or Heavy-Duty Vehicles (Subject to ACF)",
+    "C":   "Body-Type Exempt Vehicles (Excluded from ACF)",
+    "D":   "Emergency Vehicles (Excluded from ACF)",
+}
+
+# Canonical display labels as stored in custom_fields["ACF Category"] by acf_compliance.py.
+# Used to keep ACF Category consistent after manual overrides.
+ACF_CODE_TO_LABEL: dict = {
+    "ZEV": "Zero-Emission Vehicle",
+    "A":   "Exempt — Light-Duty",
+    "B":   "Subject to ACF",
+    "C":   "Exempt — Body Type",
     "D":   "Emergency Vehicle",
+}
+ACF_LABEL_TO_CODE: dict = {v: k for k, v in ACF_CODE_TO_LABEL.items()}
+
+# Short versions for tight UI spaces (dropdowns, Gantt axis, etc.)
+ACF_LABELS_SHORT = {
+    "ZEV": "Already Zero-Emission",
+    "A":   "Light Duty (Excl. ACF)",
+    "B":   "Medium/Heavy-Duty (Subject to ACF)",
+    "C":   "Body-Type Exempt (Excl. ACF)",
+    "D":   "Emergency Vehicle (Excl. ACF)",
 }
 
 
@@ -144,7 +166,7 @@ def _show_acf_ev_year_dialog(parent, old_acf: str, new_acf: str,
 
     ttk.Label(
         msg_frame,
-        text=f"  From:  {old_acf} — {old_label}\n  To:      {new_acf} — {new_label}",
+        text=f"  From:  {old_label}\n  To:      {new_label}",
         justify="left",
     ).pack(anchor="w", pady=(4, 8))
 
@@ -343,7 +365,7 @@ def _gantt_grouped(ax, vehicles: list, years: list) -> None:
 
     cat_pos = {c: i for i, c in enumerate(reversed(cats))}
     ax.set_yticks(list(cat_pos.values()))
-    ax.set_yticklabels([ACF_LABELS.get(c, c) for c in reversed(cats)], fontsize=8)
+    ax.set_yticklabels([ACF_LABELS_SHORT.get(c, c) for c in reversed(cats)], fontsize=8)
     ax.set_ylim(-0.7, len(cats) - 0.3)
 
     for cat in cats:
@@ -592,6 +614,10 @@ class AnalysisPanel(ttk.Frame):
         self._scenario_cost_fig    = None
         self._scenario_cost_canvas = None
 
+        # ── ZEV Purchase Schedule chart ───────────────────────────────────────
+        self._purchase_fig    = None
+        self._purchase_canvas = None
+
         # ── Stale analysis tracking ───────────────────────────────────────────
         self._analysis_is_stale = False
 
@@ -618,7 +644,8 @@ class AnalysisPanel(ttk.Frame):
           3. Fleet Snapshot KPIs
           4. Scenario Comparison (primary analytical view)
           5. Chart Gallery (replaces old Chart Browser)
-          6. Electrification Timeline Gantt
+          6. ZEV Purchase Schedule (stacked bar, always visible after analysis)
+          7. Electrification Timeline Gantt
           7. TCO Summary
           8. Top-5 Priority / ACF Donut (collapsible, starts collapsed)
           9. Export bar
@@ -641,6 +668,9 @@ class AnalysisPanel(ttk.Frame):
         ttk.Separator(dash, orient=tk.HORIZONTAL).pack(fill=tk.X, pady=Spacing.MD)
 
         self._create_chart_gallery_section(dash)
+        ttk.Separator(dash, orient=tk.HORIZONTAL).pack(fill=tk.X, pady=Spacing.MD)
+
+        self._create_purchase_schedule_section(dash)
         ttk.Separator(dash, orient=tk.HORIZONTAL).pack(fill=tk.X, pady=Spacing.MD)
 
         self._create_gantt_section(dash)
@@ -847,7 +877,7 @@ class AnalysisPanel(ttk.Frame):
             rf.pack(anchor="w")
             tk.Label(rf, text="●", foreground=ACF_COLORS.get(cat, "#888"),
                      font=(Fonts.FAMILY_SANS, Fonts.SIZE_SMALL)).pack(side=tk.LEFT)
-            lbl = ttk.Label(rf, text=f"Category {cat}: —",
+            lbl = ttk.Label(rf, text=f"{ACF_LABELS_SHORT.get(cat, cat)}: —",
                             font=(Fonts.FAMILY_SANS, Fonts.SIZE_SMALL))
             lbl.pack(side=tk.LEFT, padx=(2, 0))
             self._acf_count_labels[cat] = lbl
@@ -867,14 +897,14 @@ class AnalysisPanel(ttk.Frame):
         cb_row.pack(fill=tk.X, padx=Spacing.SM, pady=(Spacing.XS, 0))
 
         scope_labels = {
-            "minimum_compliance":    "Minimum Compliance (Cat B only)",
-            "all_except_emergency":  "All Excl. Emergency (A+B+C)",
-            "whole_fleet":           "Whole Fleet (A+B+C+D)",
+            "minimum_compliance":    "Minimum Compliance (M/HD Subject to ACF only)",
+            "all_except_emergency":  "All Excl. Emergency (Light Duty + M/HD + Body-Type Exempt)",
+            "whole_fleet":           "Whole Fleet (All categories)",
         }
         scope_tips = {
-            "minimum_compliance":   "Only ACF mandate-subject vehicles (medium & heavy duty, Cat B).\nShows the bare minimum required by CARB.",
-            "all_except_emergency": "All vehicles except emergency (Cat A light-duty, Cat B mandate-subject, Cat C body-type exempt).\nTypical planning scope for most clients.",
-            "whole_fleet":          "Every vehicle including emergency vehicles (Cat A+B+C+D).\nShows the full fleet electrification cost and CO\u2082 benefit.",
+            "minimum_compliance":   "Only medium and heavy-duty vehicles subject to ACF mandate.\nShows the bare minimum required by CARB.",
+            "all_except_emergency": "All vehicles except emergency vehicles \u2014 includes light duty, M/HD subject, and body-type exempt.\nTypical planning scope for most clients.",
+            "whole_fleet":          "Every vehicle including emergency vehicles.\nShows the full fleet electrification cost and CO\u2082 benefit.",
         }
         for key, label in scope_labels.items():
             cb = ttk.Checkbutton(
@@ -1006,6 +1036,116 @@ class AnalysisPanel(ttk.Frame):
             self._tco_kpi_labels[key] = val_lbl
 
         self.kpi_labels.update(self._tco_kpi_labels)
+
+    # ── ZEV Purchase Schedule (standalone stacked bar, always visible) ─────────
+
+    def _create_purchase_schedule_section(self, parent):
+        """Stacked bar chart: vehicles-per-year by ACF designation (current plan)."""
+        section = ttk.LabelFrame(parent, text="ZEV Purchase Schedule — Vehicles by Year")
+        section.pack(fill=tk.BOTH, padx=Spacing.SM, pady=(0, Spacing.SM))
+
+        self._purchase_fig = Figure(figsize=(9, 3.4), dpi=80)
+        self._purchase_fig.patch.set_facecolor(Colors.SURFACE)
+        canvas = FigureCanvasTkAgg(self._purchase_fig, master=section)
+        canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True,
+                                    padx=Spacing.SM, pady=Spacing.SM)
+        self._purchase_canvas = canvas
+
+        ax = self._purchase_fig.add_subplot(111)
+        ax.text(0.5, 0.5, "Run Full Analysis to populate.",
+                ha="center", va="center", fontsize=9, color=Colors.TEXT_TERTIARY)
+        ax.axis("off")
+        self._purchase_canvas.draw()
+
+    def _update_purchase_schedule_chart(self):
+        """Redraw the ZEV Purchase Schedule stacked bar from fleet data."""
+        if self._purchase_fig is None or self._purchase_canvas is None:
+            return
+
+        self._purchase_fig.clear()
+        ax = self._purchase_fig.add_subplot(111)
+
+        if not self.fleet or not self.fleet.vehicles:
+            ax.text(0.5, 0.5, "No fleet data available.",
+                    ha="center", va="center", fontsize=9, color=Colors.TEXT_TERTIARY)
+            ax.axis("off")
+            self._purchase_canvas.draw()
+            return
+
+        # Series definition: code → (display label, color)
+        SERIES = [
+            ("A", "Light Duty Vehicles (Excluded from ACF)",          ACF_COLORS["A"]),
+            ("B", "Medium or Heavy-Duty Vehicles (Subject to ACF)",   ACF_COLORS["B"]),
+            ("C", "Body-Type Exempt Vehicles (Excluded from ACF)",    ACF_COLORS["C"]),
+            ("D", "Emergency Vehicles (Excluded from ACF)",           ACF_COLORS["D"]),
+        ]
+
+        import datetime as _dt
+        current_year = _dt.datetime.now().year
+        start_year = max(current_year, 2026)
+        end_year = 2045
+
+        # Build year × code matrix
+        year_counts: Dict[int, Dict[str, int]] = {
+            yr: {code: 0 for code, _, _ in SERIES}
+            for yr in range(start_year, end_year + 1)
+        }
+        valid_codes = {code for code, _, _ in SERIES}
+        has_any = False
+        for v in self.fleet.vehicles:
+            code = v.custom_fields.get("_acf_code", "")
+            if code not in valid_codes:
+                continue
+            yr_str = v.custom_fields.get("Proposed EV Year", "")
+            try:
+                yr = int(yr_str)
+                if start_year <= yr <= end_year:
+                    year_counts[yr][code] += 1
+                    has_any = True
+            except (ValueError, TypeError):
+                pass
+
+        if not has_any:
+            ax.text(0.5, 0.5,
+                    "No electrification years assigned.\nRun Full Analysis first.",
+                    ha="center", va="center", fontsize=9, color=Colors.TEXT_TERTIARY)
+            ax.axis("off")
+            self._purchase_canvas.draw()
+            return
+
+        years = list(range(start_year, end_year + 1))
+        x = list(range(len(years)))
+        bottoms = [0] * len(years)
+
+        for code, label, color in SERIES:
+            vals = [year_counts[yr][code] for yr in years]
+            if sum(vals) == 0:
+                continue
+            bars = ax.bar(x, vals, bottom=bottoms, color=color, label=label,
+                          edgecolor="white", linewidth=0.5)
+            # Show count on bars > 0
+            for bar, val, bot in zip(bars, vals, bottoms):
+                if val > 0:
+                    ax.text(bar.get_x() + bar.get_width() / 2,
+                            bot + val / 2, str(val),
+                            ha="center", va="center", fontsize=6.5,
+                            color="white", fontweight="bold")
+            bottoms = [b + v for b, v in zip(bottoms, vals)]
+
+        ax.set_xticks(x)
+        ax.set_xticklabels([str(y) for y in years], fontsize=7, rotation=45, ha="right")
+        ax.set_ylabel("Vehicles for Replacement", fontsize=8)
+        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+        ax.set_xlim(-0.6, len(years) - 0.4)
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        ax.tick_params(axis="y", labelsize=7)
+        ax.legend(fontsize=7, loc="upper left", frameon=True,
+                  facecolor=Colors.SURFACE, edgecolor="#CCCCCC")
+        self._purchase_fig.patch.set_facecolor(Colors.SURFACE)
+        ax.set_facecolor(Colors.SURFACE)
+        self._purchase_fig.tight_layout(pad=0.5)
+        self._purchase_canvas.draw()
 
     # ── Electrification Gantt (collapsible, starts collapsed) ─────────────────
 
@@ -1163,6 +1303,8 @@ class AnalysisPanel(ttk.Frame):
         self._gallery_pptx_vars: Dict[str, tk.BooleanVar] = {}
         self._gallery_thumb_frames: Dict[str, tk.Frame] = {}
         self._gallery_thumb_rendered = False
+        self._thumb_render_queue: list = []
+        self._thumb_render_vars: dict = {}
 
         # Populate thumbnail placeholders immediately (text cards, no renders yet)
         self._build_thumbnail_placeholders()
@@ -1220,67 +1362,85 @@ class AnalysisPanel(ttk.Frame):
         if not self.fleet:
             return
         self._gallery_thumb_rendered = True
-        # Render each chart in the background to avoid freezing the UI
-        threading.Thread(target=self._render_all_thumbnails, daemon=True).start()
+        # Snapshot Tkinter variable values now (main thread) so render loop doesn't touch them
+        self._thumb_render_vars = {
+            "gas_price": self.gas_price_var.get(),
+            "electricity_price": self.electricity_price_var.get(),
+            "ev_efficiency": self.ev_efficiency_var.get(),
+            "color_scheme": self.color_scheme_var.get(),
+        }
+        self._thumb_render_queue = list(CHART_TYPES)
+        self.after(0, self._render_next_thumbnail)
 
-    def _render_all_thumbnails(self):
-        """Background thread: render each chart type as a small thumbnail."""
-        if not _PIL_AVAILABLE:
+    def _render_next_thumbnail(self):
+        """Render one thumbnail per event-loop tick (main thread, no pyplot global state)."""
+        if not _PIL_AVAILABLE or not self._thumb_render_queue:
             return
         THUMB_W, THUMB_H = 136, 82
-        for chart_type in CHART_TYPES:
-            try:
-                thumb_fig = Figure(figsize=(2.2, 1.35), dpi=62)
-                # Build same extra_args logic as _update_chart
-                chart_data = self.fleet
-                extra_args = {}
-                if chart_type == "Fleet Cash Flow" and self.electrification_analysis:
-                    chart_data = self.electrification_analysis
-                elif chart_type == "Electrification Potential" and self.electrification_analysis:
-                    chart_data = self.electrification_analysis
-                    extra_args = {
-                        "gas_price": self.gas_price_var.get(),
-                        "electricity_price": self.electricity_price_var.get(),
-                        "ev_efficiency": self.ev_efficiency_var.get(),
-                    }
-                elif chart_type in ("Emissions Reduction", "ROI Analysis") \
-                        and self.electrification_analysis:
-                    chart_data = self.electrification_analysis
-                elif chart_type in ("Annual Cost Comparison",):
-                    extra_args = {
-                        "gas_price": self.gas_price_var.get(),
-                        "electricity_price": self.electricity_price_var.get(),
-                        "ev_efficiency": self.ev_efficiency_var.get(),
-                    }
-                elif "Emission" in chart_type and self.emissions_inventory:
-                    chart_data = self.emissions_inventory
-                elif "Charging" in chart_type and self.charging_analysis:
-                    chart_data = self.charging_analysis
+        chart_type = self._thumb_render_queue.pop(0)
+        vars_ = self._thumb_render_vars
+        try:
+            thumb_fig = Figure(figsize=(2.2, 1.35), dpi=62)
+            chart_data = self.fleet
+            extra_args = {}
+            if chart_type == "Fleet Cash Flow" and self.electrification_analysis:
+                chart_data = self.electrification_analysis
+            elif chart_type == "Electrification Potential" and self.electrification_analysis:
+                chart_data = self.electrification_analysis
+                extra_args = {
+                    "gas_price": vars_["gas_price"],
+                    "electricity_price": vars_["electricity_price"],
+                    "ev_efficiency": vars_["ev_efficiency"],
+                }
+            elif chart_type in ("Emissions Reduction", "ROI Analysis") \
+                    and self.electrification_analysis:
+                chart_data = self.electrification_analysis
+            elif chart_type in ("Annual Cost Comparison",):
+                extra_args = {
+                    "gas_price": vars_["gas_price"],
+                    "electricity_price": vars_["electricity_price"],
+                    "ev_efficiency": vars_["ev_efficiency"],
+                }
+            elif "Emission" in chart_type and self.emissions_inventory:
+                chart_data = self.emissions_inventory
+            elif "Charging" in chart_type and self.charging_analysis:
+                chart_data = self.charging_analysis
 
-                ChartFactory.create_chart(
-                    chart_type=chart_type, data=chart_data, figure=thumb_fig,
-                    chart_style="minimal", color_scheme=self.color_scheme_var.get(),
-                    **extra_args,
-                )
-                thumb_fig.tight_layout(pad=0.1)
+            ChartFactory.create_chart(
+                chart_type=chart_type, data=chart_data, figure=thumb_fig,
+                chart_style="minimal", color_scheme=vars_["color_scheme"],
+                **extra_args,
+            )
+            # Strip all text decorations — at 136×82px they'd be unreadable smears
+            # and prevent tight_layout from fitting anyway.
+            for ax in thumb_fig.get_axes():
+                ax.set_title("")
+                ax.set_xlabel("")
+                ax.set_ylabel("")
+                ax.set_xticklabels([])
+                ax.set_yticklabels([])
+                ax.tick_params(left=False, bottom=False)
+            thumb_fig.tight_layout(pad=0.1)
 
-                buf = _io.BytesIO()
-                thumb_fig.savefig(buf, format="png", dpi=62,
-                                  bbox_inches="tight", facecolor="white")
-                buf.seek(0)
-                img = _PILImage.open(buf).resize((THUMB_W, THUMB_H), _PILImage.LANCZOS)
-                photo = _ImageTk.PhotoImage(img)
-                matplotlib.pyplot.close(thumb_fig)
-                buf.close()
+            buf = _io.BytesIO()
+            thumb_fig.savefig(buf, format="png", dpi=62,
+                              bbox_inches="tight", facecolor="white")
+            buf.seek(0)
+            raw_img = _PILImage.open(buf)
+            resized = raw_img.resize((THUMB_W, THUMB_H), _PILImage.LANCZOS)
+            raw_img.close()
+            photo = _ImageTk.PhotoImage(resized)
+            resized.close()
+            thumb_fig.clear()
+            buf.close()
 
-                self._chart_thumbnails[chart_type] = photo
-                # Schedule UI update on main thread
-                self.after(0, lambda ct=chart_type, ph=photo: self._apply_thumbnail(ct, ph))
-                # Discard the small figure to free memory
-                thumb_fig.clear()
-                del thumb_fig
-            except Exception as err:
-                logger.debug(f"Thumbnail render failed for {chart_type!r}: {err}")
+            self._chart_thumbnails[chart_type] = photo
+            self._apply_thumbnail(chart_type, photo)
+        except Exception as err:
+            logger.debug(f"Thumbnail render failed for {chart_type!r}: {err}")
+
+        if self._thumb_render_queue:
+            self.after(10, self._render_next_thumbnail)
 
     def _apply_thumbnail(self, chart_type: str, photo):
         """Update a thumbnail card with a rendered image (called on main thread)."""
@@ -1488,7 +1648,7 @@ class AnalysisPanel(ttk.Frame):
 
         ttk.Label(
             fleet_frame,
-            text="Affects CARB ACF mandate deadlines for Category B vehicles.\n"
+            text="Affects CARB ACF mandate deadlines for medium and heavy-duty vehicles subject to ACF.\n"
                  "Verify non-HPF milestones against current CARB regulatory text.",
             foreground="#666666",
             justify="left",
@@ -2172,12 +2332,18 @@ class AnalysisPanel(ttk.Frame):
                 progress.update(85, "Generating report...")
                 generator = ReportGeneratorFactory.create_generator(filepath)
                 if generator:
+                    # Cover-page client/date/presenter come from the per-fleet profile.
+                    client_profile = (self.sharing_data.get("presentation_profile")
+                                      if self.sharing_data is not None else None)
+                    state_code = getattr(self.fleet, "state_code", "") or "CA"
                     success = generator.generate(
                         fleet=self.fleet,
                         analysis=self.electrification_analysis,
                         charging=self.charging_analysis,
                         emissions=self.emissions_inventory,
                         timeline_options=timeline_options,
+                        client_profile=client_profile,
+                        state_code=state_code,
                     )
                     if success:
                         progress.update(100, "Report complete!")
@@ -2572,6 +2738,7 @@ class AnalysisPanel(ttk.Frame):
         self._update_priority_vehicles()
         self._update_tco_kpis()
         self._update_status_label()
+        self._update_purchase_schedule_chart()
         self._update_gantt_section()
         self._update_export_button_states()
 
@@ -2630,7 +2797,7 @@ class AnalysisPanel(ttk.Frame):
         self._snapshot_kpi_labels["fleet_size"].config(text=str(n))
 
         acf_b = sum(1 for v in vehicles
-                    if v.custom_fields.get("ACF Category", "") == "B")
+                    if v.custom_fields.get("_acf_code", "") == "B")
         self._snapshot_kpi_labels["acf_b_count"].config(text=str(acf_b))
 
         avg_mpg = self.fleet.avg_mpg
@@ -2658,7 +2825,7 @@ class AnalysisPanel(ttk.Frame):
             ax.axis("off")
             self._acf_canvas.draw()
             for cat, lbl in self._acf_count_labels.items():
-                lbl.config(text=f"Category {cat}: —")
+                lbl.config(text=f"{ACF_LABELS_SHORT.get(cat, cat)}: —")
             return
 
         counts: Dict[str, int] = {"ZEV": 0, "A": 0, "B": 0, "C": 0, "D": 0}
@@ -2693,7 +2860,9 @@ class AnalysisPanel(ttk.Frame):
         self._acf_canvas.draw()
 
         for cat, lbl in self._acf_count_labels.items():
-            lbl.config(text=f"Category {cat}: {counts.get(cat, 0)}")
+            n = counts.get(cat, 0)
+            pct = f" ({n/total:.0%})" if total > 0 and n > 0 else ""
+            lbl.config(text=f"{ACF_LABELS_SHORT.get(cat, cat)}: {n}{pct}")
 
     def _update_priority_vehicles(self):
         """Populate Top 5 Priority Vehicles table from electrification_analysis."""
@@ -2858,7 +3027,7 @@ class AnalysisPanel(ttk.Frame):
             vehicle.custom_fields["Original ACF Category"] = (
                 vehicle.custom_fields.get("ACF Category", "")
             )
-        vehicle.custom_fields["ACF Category"] = new_acf_code
+        vehicle.custom_fields["ACF Category"] = ACF_CODE_TO_LABEL.get(new_acf_code, new_acf_code)
         vehicle.custom_fields["_acf_code"] = new_acf_code
         vehicle.custom_fields["ACF Category Overridden"] = "Yes"
 
@@ -2868,7 +3037,7 @@ class AnalysisPanel(ttk.Frame):
         original = vehicle.custom_fields.get("Original ACF Category")
         if original is not None:
             vehicle.custom_fields["ACF Category"] = original
-            vehicle.custom_fields["_acf_code"] = original
+            vehicle.custom_fields["_acf_code"] = ACF_LABEL_TO_CODE.get(original, original)
         vehicle.custom_fields.pop("ACF Category Overridden", None)
         vehicle.custom_fields.pop("Original ACF Category", None)
 

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -193,7 +193,9 @@ class MainWindow:
         file_menu = Menu(menubar, tearoff=0)
         file_menu.add_command(label="New Fleet", command=self.new_fleet)
         file_menu.add_command(label="Open Input File...", command=self.open_input_file)
+        file_menu.add_command(label="Open Project...", command=self.open_project)
         file_menu.add_separator()
+        file_menu.add_command(label="Save Project...", command=self.save_project_file)
         file_menu.add_command(label="Save Results...", command=self.save_results)
         file_menu.add_command(label="Export Report...", command=self.export_report)
         file_menu.add_separator()
@@ -453,9 +455,11 @@ class MainWindow:
         except Exception as exc:
             logger.warning(f"Could not refresh Timeline after ACF override: {exc}")
         try:
+            self.analysis_panel._update_purchase_schedule_chart()
             self.analysis_panel._update_gantt_section()
+            self.analysis_panel._update_acf_donut()
         except Exception as exc:
-            logger.warning(f"Could not refresh Analysis Gantt after ACF override: {exc}")
+            logger.warning(f"Could not refresh Analysis charts after ACF override: {exc}")
 
     def _reset_all_ev_overrides(self):
         """Tools menu: reset all manual EV-year overrides in the current fleet."""
@@ -651,7 +655,97 @@ class MainWindow:
         user clicked.
         """
         self.analysis_panel.export_full_report()
-    
+
+    # ------------------------------------------------------------------
+    # Project save / load (.fea)
+    # ------------------------------------------------------------------
+
+    def save_project_file(self):
+        """Serialize the current Fleet + scenario results to a .fea file."""
+        if not self.fleet.vehicles:
+            messagebox.showinfo("No Data", "There are no vehicles to save.")
+            return
+
+        filepath = filedialog.asksaveasfilename(
+            title="Save Project",
+            defaultextension=".fea",
+            filetypes=[("Fleet Electrification Analyzer Project", "*.fea"),
+                       ("All Files", "*.*")],
+        )
+        if not filepath:
+            return
+
+        try:
+            from data.project_io import save_project
+            scenario_results = None
+            try:
+                scenario_results = self.sharing_data.get("scenario_results")
+            except Exception:
+                pass
+            save_project(filepath, self.fleet, scenario_results)
+            messagebox.showinfo(
+                "Project Saved",
+                f"Project saved to:\n{filepath}",
+            )
+            self.status_bar.set(f"Project saved — {len(self.fleet.vehicles)} vehicles")
+        except Exception as exc:
+            logger.error("save_project_file error: %s", exc, exc_info=True)
+            messagebox.showerror("Save Failed", f"Could not save project:\n{exc}")
+
+    def open_project(self):
+        """Load a .fea project file, bypassing the VIN-processing pipeline."""
+        if self.fleet.vehicles:
+            if not messagebox.askyesno(
+                "Open Project",
+                "This will replace the current fleet. Continue?",
+            ):
+                return
+
+        filepath = filedialog.askopenfilename(
+            title="Open Project",
+            filetypes=[("Fleet Electrification Analyzer Project", "*.fea"),
+                       ("All Files", "*.*")],
+        )
+        if not filepath:
+            return
+
+        try:
+            from data.project_io import load_project
+            fleet, scenario_results = load_project(filepath)
+        except Exception as exc:
+            logger.error("open_project error: %s", exc, exc_info=True)
+            messagebox.showerror("Open Failed", f"Could not load project:\n{exc}")
+            return
+
+        # Install the fleet
+        self.fleet = fleet
+        self.results_data = list(fleet.vehicles)
+
+        self.results_panel.set_data(fleet.vehicles)
+        self.analysis_panel.set_fleet(fleet)
+        self.timeline_panel.set_fleet(
+            fleet,
+            on_year_changed=self._on_timeline_year_changed,
+            on_acf_changed=self._on_acf_override,
+        )
+        self.sharing_data.set("fleet", fleet)
+        self.present_panel.refresh_data()
+
+        # Restore scenario results if they were saved
+        if scenario_results is not None:
+            try:
+                self.sharing_data.set("scenario_results", scenario_results)
+                self.analysis_panel.scenario_results = scenario_results
+            except Exception as exc:
+                logger.warning("Could not restore scenario results: %s", exc)
+
+        self.update_vehicle_count()
+        self.notebook.select(1)  # jump to Results tab
+        self.status_bar.set(
+            f"Project loaded — {len(fleet.vehicles)} vehicles "
+            f"(fleet type: {fleet.fleet_type})"
+        )
+
     def copy_selection(self):
         """Copy the current selection to the clipboard."""
         current_tab = self.notebook.index(self.notebook.select())

--- a/ui/results_panel.py
+++ b/ui/results_panel.py
@@ -1063,7 +1063,7 @@ Summary of Selected Vehicles ({len(selected_vehicles)})
         Shows a small dialog with a dropdown of all valid ACF categories.
         If the user confirms, applies the override and fires on_acf_override_callback.
         """
-        from ui.analysis_panel import ACF_LABELS, _show_acf_ev_year_dialog, AnalysisPanel
+        from ui.analysis_panel import ACF_LABELS, ACF_CODE_TO_LABEL, ACF_LABEL_TO_CODE, _show_acf_ev_year_dialog, AnalysisPanel
         from analysis.electrification_timeline import assign_electrification_years
 
         selected_iids = self.tree.selection()
@@ -1075,11 +1075,12 @@ Summary of Selected Vehicles ({len(selected_vehicles)})
         if vehicle is None:
             return
 
-        old_code = vehicle.custom_fields.get("ACF Category", "")
+        old_label = vehicle.custom_fields.get("ACF Category", "")
+        old_code = vehicle.custom_fields.get("_acf_code", "")
 
         # ── Category picker dialog ────────────────────────────────────────────
         picker = tk.Toplevel(self)
-        picker.title("Override ACF Category")
+        picker.title("Override Vehicle ACF Designation")
         picker.resizable(False, False)
         picker.transient(self.winfo_toplevel())
         picker.grab_set()
@@ -1098,30 +1099,20 @@ Summary of Selected Vehicles ({len(selected_vehicles)})
 
         ttk.Label(
             picker,
-            text=f"Override ACF Category for:\n{vehicle_label}",
+            text=f"Override ACF Designation for:\n{vehicle_label}",
             font=("TkDefaultFont", 10, "bold"),
         ).pack(padx=20, pady=(16, 4), anchor="w")
 
         ttk.Label(
             picker,
-            text=f"Current category: {old_code} — {ACF_LABELS.get(old_code, old_code)}",
+            text=f"Current: {old_label}",
             foreground="#555",
         ).pack(padx=20, pady=(0, 8), anchor="w")
 
-        ttk.Label(picker, text="New category:").pack(padx=20, anchor="w")
-        options = [
-            f"ZEV — {ACF_LABELS['ZEV']}",
-            f"A — {ACF_LABELS['A']}",
-            f"B — {ACF_LABELS['B']}",
-            f"C — {ACF_LABELS['C']}",
-            f"D — {ACF_LABELS['D']}",
-        ]
-        combo = ttk.Combobox(picker, values=options, state="readonly", width=28)
-        # Pre-select current category
-        current_option = next(
-            (opt for opt in options if opt.startswith(old_code + " — ")),
-            options[0],
-        )
+        ttk.Label(picker, text="New designation:").pack(padx=20, anchor="w")
+        options = list(ACF_CODE_TO_LABEL.values())
+        combo = ttk.Combobox(picker, values=options, state="readonly", width=48)
+        current_option = old_label if old_label in options else options[0]
         combo.set(current_option)
         combo.pack(padx=20, pady=(4, 12), anchor="w")
 
@@ -1146,7 +1137,7 @@ Summary of Selected Vehicles ({len(selected_vehicles)})
         if raw_choice == "cancel" or not raw_choice:
             return
 
-        new_code = raw_choice.split(" — ")[0].strip()
+        new_code = ACF_LABEL_TO_CODE.get(raw_choice, raw_choice)
         if new_code == old_code:
             return  # No change
 
@@ -1210,7 +1201,7 @@ Summary of Selected Vehicles ({len(selected_vehicles)})
 
         dialog = tk.Toplevel(self)
         dialog.title("Save MPG to Database")
-        dialog.geometry("440x400")
+        dialog.geometry("440x460")
         dialog.resizable(False, False)
         dialog.transient(self.winfo_toplevel())
         dialog.grab_set()
@@ -1299,6 +1290,29 @@ Summary of Selected Vehicles ({len(selected_vehicles)})
         add_row("MPG City:",       "mpg_city",     mpg_city, 8)
         add_row("MPG Highway:",    "mpg_highway",  mpg_hwy,  8)
 
+        # GVWR weight class — pre-select from decoded vehicle data
+        _GVWR_OPTIONS = [
+            "",
+            "Class 2b–4 (8,501–19,500 lbs)",
+            "Class 5–8a (19,501–33,000 lbs)",
+            "Class 8b (33,001+ lbs)",
+        ]
+        _GVWR_BOUNDS = {
+            "Class 2b–4 (8,501–19,500 lbs)":   (8501,  19500),
+            "Class 5–8a (19,501–33,000 lbs)":  (19501, 33000),
+            "Class 8b (33,001+ lbs)":                    (33001, None),
+        }
+        gvwr_lbs = vehicle.vehicle_id.gvwr_pounds or 0
+        if gvwr_lbs > 33000:
+            _gvwr_default = "Class 8b (33,001+ lbs)"
+        elif gvwr_lbs > 19500:
+            _gvwr_default = "Class 5–8a (19,501–33,000 lbs)"
+        elif gvwr_lbs > 8500:
+            _gvwr_default = "Class 2b–4 (8,501–19,500 lbs)"
+        else:
+            _gvwr_default = ""
+        add_combo("GVWR Class:", "gvwr_class", _GVWR_OPTIONS, _gvwr_default, 28)
+
         add_combo("Source:", "source",
                   ["analyst", "manufacturer_spec", "fuelly", "epa_label", "fleet_record"],
                   "analyst", 18)
@@ -1356,6 +1370,9 @@ Summary of Selected Vehicles ({len(selected_vehicles)})
                 except ValueError:
                     return 0.0
 
+            gvwr_sel = fields["gvwr_class"].get().strip()
+            gvwr_min, gvwr_max = _GVWR_BOUNDS.get(gvwr_sel, (None, None))
+
             try:
                 self.db_manager.add_ice_vehicle(
                     year         = year,
@@ -1363,6 +1380,8 @@ Summary of Selected Vehicles ({len(selected_vehicles)})
                     model        = model,
                     fuel_type    = fields["fuel_type"].get().strip() or None,
                     body_class   = vehicle.vehicle_id.body_class or None,
+                    gvwr_lbs_min = gvwr_min,
+                    gvwr_lbs_max = gvwr_max,
                     mpg_combined = mpg_combined,
                     mpg_city     = _safe_float("mpg_city"),
                     mpg_highway  = _safe_float("mpg_highway"),
@@ -1687,5 +1706,5 @@ Summary of Selected Vehicles ({len(selected_vehicles)})
         # Still not found, try the vehicle's get_field method as last resort
         try:
             return vehicle.get_field(col_id)
-        except:
+        except Exception:
             return ""

--- a/ui/timeline_panel.py
+++ b/ui/timeline_panel.py
@@ -12,6 +12,7 @@ Provides:
 """
 
 import logging
+import warnings
 import tkinter as tk
 from tkinter import ttk, messagebox
 from typing import Callable, Dict, List, Optional
@@ -56,15 +57,23 @@ _ACF_COL = "acf"           # column id for the ACF category cell
 _ACF_COL_NUM = 5           # 1-based column number ("#5") in the Treeview
 
 # Combobox options for ACF category inline edit: "CODE — Plain Label"
+# Dropdown options for the inline ACF editor — match ACF Category stored values exactly
 _ACF_OPTIONS = [
-    "ZEV — Already ZEV",
-    "A — Light-Duty (Exempt)",
-    "B — Mandate-Subject",
-    "C — Body-Type Exempt",
-    "D — Emergency Vehicle",
+    "Zero-Emission Vehicle",
+    "Exempt — Light-Duty",
+    "Subject to ACF",
+    "Exempt — Body Type",
+    "Emergency Vehicle",
 ]
+_ACF_OPTION_TO_CODE = {
+    "Zero-Emission Vehicle": "ZEV",
+    "Exempt — Light-Duty":   "A",
+    "Subject to ACF":        "B",
+    "Exempt — Body Type":    "C",
+    "Emergency Vehicle":     "D",
+}
 
-# Full plain-English labels used in the filter bar checkbuttons
+# Short labels used in the filter bar checkbuttons
 _ACF_FILTER_LABELS = {
     "ZEV": "Already ZEV",
     "A":   "Light-Duty (Exempt)",
@@ -201,8 +210,7 @@ class TimelinePanel(ttk.Frame):
                 command=self._apply_filter,
             )
             cb.pack(side=tk.LEFT, padx=(0, 6))
-            SimpleTooltip(cb,
-                f"Show/hide Category {cat} vehicles\n({_ACF_FILTER_LABELS[cat]})")
+            SimpleTooltip(cb, f"Show/hide {_ACF_FILTER_LABELS[cat]} vehicles")
 
         # ── EV year range ─────────────────────────────────────────────────────
         ttk.Label(inner, text="  EV Year:").pack(side=tk.LEFT, padx=(Spacing.SM, 3))
@@ -598,12 +606,8 @@ class TimelinePanel(ttk.Frame):
 
         self._cancel_edit()
 
-        current_code = self._tree.set(row_iid, _ACF_COL)
-        # Pre-select the matching option
-        current_option = next(
-            (opt for opt in _ACF_OPTIONS if opt.startswith(current_code + " ")),
-            _ACF_OPTIONS[0],
-        )
+        current_label = self._tree.set(row_iid, _ACF_COL)
+        current_option = current_label if current_label in _ACF_OPTIONS else _ACF_OPTIONS[0]
 
         combo = ttk.Combobox(
             self._tree,
@@ -670,16 +674,14 @@ class TimelinePanel(ttk.Frame):
     def _commit_acf(self, row_iid: str, vehicle: FleetVehicle, selected: str):
         """Validate and apply an ACF category override after dropdown selection.
 
-        ``selected`` is a string like "B — Mandate-Subject"; the code is
-        extracted by splitting on " — " and taking the first token.
+        ``selected`` is a full label string like "Subject to ACF".
         """
-        new_code = selected.split(" — ")[0].strip()
-        valid_codes = {"ZEV", "A", "B", "C", "D"}
-        if new_code not in valid_codes:
+        new_code = _ACF_OPTION_TO_CODE.get(selected)
+        if not new_code:
             logger.warning(f"Unrecognised ACF option selected: {selected!r}")
             return
 
-        old_code = vehicle.custom_fields.get("ACF Category", "")
+        old_code = vehicle.custom_fields.get("_acf_code", "")
         if new_code == old_code:
             return  # No change — nothing to do
 
@@ -772,7 +774,9 @@ class TimelinePanel(ttk.Frame):
                     max_v = 0
 
         _draw_gantt_chart(ax, vehicles, view, max_vehicles=max_v)
-        self._gantt_fig.tight_layout(pad=0.5)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            self._gantt_fig.tight_layout(pad=0.5)
         self._gantt_canvas.draw()
 
     # =========================================================================


### PR DESCRIPTION
## Summary

Rebuilds the Analysis-tab Excel report from **8 loosely-coupled sheets into a cohesive cover + 6**, fixes a real financial bug, and adds incentives, a capital plan, scenario comparison, and a data-gaps punch list. All content is driven from a single canonical assumptions block on the Cover.

## Sheet structure (cover + 6)

| # | Sheet | Highlights |
|---|-------|-----------|
| 0 | **Cover & Methodology** | Client header, **canonical single-source-of-truth assumptions** (`Cover!$B$9:$B$18`), data-quality KPIs, methodology, ACF glossary |
| 1 | **Vehicle Data** | Quality-flag highlighting (MPG estimates, low quality/confidence, failures) |
| 2 | **Fleet Overview** | Merged Summary + Dashboard; KPI band + native pie/column charts |
| 3 | **TCO & Financials** | Assumptions mirror the Cover by formula; Funding & Incentives; **$15k payback bug fixed** |
| 4 | **Replacement & Capital Plan** | Per-year capex, net-of-incentive, over-cap flag, native spend chart |
| 5 | **Emissions & Scenarios** | 4-scenario comparison + CO₂ trajectory chart; `is_synthetic` flag |
| 6 | **Infrastructure & Action Items** | Per-year charger buildout + data-gaps punch list |

## Key changes

- **Single source of truth:** the Cover holds the canonical assumptions; the TCO sheet's cells B4–B12/B14 are `='Cover…'!$B$n` mirror formulas, so downstream cash-flow formulas are untouched and one edit drives the whole model.
- **Bug fix:** per-vehicle payback previously used a hardcoded `ev_premium = 15000`; now uses each vehicle's real `_payback_years` / `_ev_purchase_price`.
- **Funding & Incentives** via `rate_database.get_all_incentives()` (light / medium_heavy buckets), net-of-incentive costs.
- Removed ~340 lines of dead code (`_create_summary_sheet`, `_create_summary_dashboard_sheet`, `_create_electrification_sheet`).
- `generate()` gained `client_profile` (from `sharing_data["presentation_profile"]`) + `state_code` (default `"CA"`).

## Testing

- New `tests/test_excel_report.py` (9 structural tests: sheet set/order, canonical assumptions, TCO→Cover mirror, no `ev_premium` hardcode, real payback, incentive net ≤ gross, scenario + action-item sections, minimal-data generation).
- **279 tests passing** (was 270).

## Notes

- Incentive state defaults to `"CA"` (reads `fleet.state_code` if present) — there is no per-vehicle registration state in the model; it's a region-level input.
- CLAUDE.md updated (Phase 29 + Excel Export section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
